### PR TITLE
Clear Ammo before Clearing Items

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2728,8 +2728,8 @@ namespace Exiled.API.Features
         /// <seealso cref="DropItems()"/>
         public void ClearInventory(bool destroy = true)
         {
-            ClearItems(destroy);
             ClearAmmo();
+            ClearItems(destroy);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently there is a bug where Clearing a Player's inventory drops some amount of ammunition. 
This is due to `BodyArmorUtils.RemoveEverythingExceedingLimits` getting called in `OnRemoved` in `InventorySystem.Items.Armor.BodyArmor`
Meaning that when the items are cleared, and armor gets removed, any additional ammo that cannot be carried will be dropped first, so when `ClearAmmo` is called it doesn't remove the dropped ammo
