### PR TITLE
`[Exiled::API]` Added WhitelistedPlayers, SetIntercomDisplayTextForTargetOnly and ResetIntercomDisplayText

### DIFF
--- a/EXILED/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/MirrorExtensions.cs
@@ -25,6 +25,7 @@ namespace Exiled.API.Extensions
     using PlayerRoles;
     using PlayerRoles.FirstPersonControl;
     using PlayerRoles.PlayableScps.Scp049.Zombies;
+    using PlayerRoles.Voice;
     using RelativePositioning;
 
     using Respawning;
@@ -180,6 +181,18 @@ namespace Exiled.API.Extensions
 
             player.Connection.Send(message);
         }
+
+        /// <summary>
+        /// Sets <see cref="Features.Intercom.DisplayText"/> that only the <paramref name="target"/> player can see.
+        /// </summary>
+        /// <param name="target">Only this player can see Display Text.</param>
+        /// <param name="text">Text displayed to the player.</param>
+        public static void SetIntercomDisplayTextForTargetOnly(this Player target, string text) => target.SendFakeSyncVar(IntercomDisplay._singleton.netIdentity, typeof(IntercomDisplay), nameof(IntercomDisplay.Network_overrideText), text);
+
+        /// <summary>
+        /// Resync <see cref="Features.Intercom.DisplayText"/>.
+        /// </summary>
+        public static void ResetIntercomDisplayText() => ResyncSyncVar(IntercomDisplay._singleton.netIdentity, typeof(IntercomDisplay), nameof(IntercomDisplay.Network_overrideText));
 
         /// <summary>
         /// Sets <see cref="Room.Color"/> of a <paramref name="room"/> that only the <paramref name="target"/> player can see.

--- a/EXILED/Exiled.API/Features/Server.cs
+++ b/EXILED/Exiled.API/Features/Server.cs
@@ -179,7 +179,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Gets the List of player currently whitelisted.
+        /// Gets the list of user IDs of players currently whitelisted.
         /// </summary>
         public static HashSet<string> WhitelistedPlayers => WhiteList.Users;
 

--- a/EXILED/Exiled.API/Features/Server.cs
+++ b/EXILED/Exiled.API/Features/Server.cs
@@ -179,6 +179,11 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Gets the List of player currently whitelisted.
+        /// </summary>
+        public static HashSet<string> WhitelistedPlayers => WhiteList.Users;
+
+        /// <summary>
         /// Gets a value indicating whether or not this server is verified.
         /// </summary>
         public static bool IsVerified => CustomNetworkManager.IsVerified;


### PR DESCRIPTION
Added to Server.cs the WhitelistedPlayers
Added to MirrorExtensions.cs SetIntercomDisplayTextForTargetOnly and ResetIntercomDisplayText

WhitelistedPlayers allows to add and modify current player whitelisted
SetIntercomDisplayTextForTargetOnly is a FakeSyncVar that allows to modify for specific target
ResetIntercomDisplayText just Resync the FakeSyncVar