### PR TITLE
Fix custom role classes giving custom ammo when they are not suppose to

### DIFF
--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -539,6 +539,21 @@ namespace Exiled.CustomRoles.API.Features
                     }
                 });
 
+            if (Ammo.Count > 0)
+            {
+                Timing.CallDelayed(
+                    0.5f,
+                    () =>
+                    {
+                        Log.Debug($"{Name}: Adding Ammo to {player.Nickname} inventory.");
+                        foreach (AmmoType type in Enum.GetValues(typeof(AmmoType)))
+                        {
+                            if (type != AmmoType.None)
+                                player.SetAmmo(type, Ammo.ContainsKey(type) ? Ammo[type] == ushort.MaxValue ? InventoryLimits.GetAmmoLimit(type.GetItemType(), player.ReferenceHub) : Ammo[type] : (ushort)0);
+                        }
+                    });
+            }
+
             Log.Debug($"{Name}: Setting health values.");
             player.Health = MaxHealth;
             player.MaxHealth = MaxHealth;
@@ -909,25 +924,6 @@ namespace Exiled.CustomRoles.API.Features
             if (Check(ev.Player) && ((ev.NewRole == RoleTypeId.Spectator && !KeepRoleOnDeath) || (ev.NewRole != RoleTypeId.Spectator && ev.NewRole != Role && !KeepRoleOnChangingRole)))
             {
                 RemoveRole(ev.Player);
-            }
-            else if (Check(ev.Player))
-            {
-                Log.Debug($"{Name}: Checking ammo stuff {Ammo.Count}");
-                if (Ammo.Count > 0)
-                {
-                    Log.Debug($"{Name}: Clearing ammo");
-                    ev.Ammo.Clear();
-                    Timing.CallDelayed(
-                        0.5f,
-                        () =>
-                        {
-                            foreach (AmmoType type in Enum.GetValues(typeof(AmmoType)))
-                            {
-                                if (type != AmmoType.None)
-                                    ev.Player.SetAmmo(type, Ammo.ContainsKey(type) ? Ammo[type] == ushort.MaxValue ? InventoryLimits.GetAmmoLimit(type.GetItemType(), ev.Player.ReferenceHub) : Ammo[type] : (ushort)0);
-                            }
-                        });
-                }
             }
         }
 

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -546,7 +546,7 @@ namespace Exiled.CustomRoles.API.Features
                     () =>
                     {
                         Log.Debug($"{Name}: Adding Ammo to {player.Nickname} inventory.");
-                        foreach (AmmoType type in Enum.GetValues(typeof(AmmoType)))
+                        foreach (AmmoType type in EnumUtils<AmmoType>.Values)
                         {
                             if (type != AmmoType.None)
                                 player.SetAmmo(type, Ammo.ContainsKey(type) ? Ammo[type] == ushort.MaxValue ? InventoryLimits.GetAmmoLimit(type.GetItemType(), player.ReferenceHub) : Ammo[type] : (ushort)0);

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -537,13 +537,8 @@ namespace Exiled.CustomRoles.API.Features
                         Log.Debug($"{Name}: Adding {itemName} to inventory.");
                         TryAddItem(player, itemName);
                     }
-                });
 
-            if (Ammo.Count > 0)
-            {
-                Timing.CallDelayed(
-                    0.5f,
-                    () =>
+                    if (Ammo.Count > 0)
                     {
                         Log.Debug($"{Name}: Adding Ammo to {player.Nickname} inventory.");
                         foreach (AmmoType type in EnumUtils<AmmoType>.Values)
@@ -551,8 +546,8 @@ namespace Exiled.CustomRoles.API.Features
                             if (type != AmmoType.None)
                                 player.SetAmmo(type, Ammo.ContainsKey(type) ? Ammo[type] == ushort.MaxValue ? InventoryLimits.GetAmmoLimit(type.GetItemType(), player.ReferenceHub) : Ammo[type] : (ushort)0);
                         }
-                    });
-            }
+                    }
+                });
 
             Log.Debug($"{Name}: Setting health values.");
             player.Health = MaxHealth;


### PR DESCRIPTION
## Description
**Describe the changes** 
Fix Custom Role Classes giving custom ammo when they are not suppose to. Moved giving custom ammo to the addrole method instead of changing role event.

**What is the current behavior?** (You can also link to an open issue here)
Custom ammo is given when the custom role class changes to a new role without losing their role in the changing role event. This causes players to re get their custom ammo if they 914 swap classes (with plugins) or escape. Using the changing role event was a fix that joker made for dropping excess ammo awhile back ago but x3rt pr'd a change already that fixed the underlying issue of that. 

**What is the new behavior?** (if this is a feature change)
Custom ammo is only given when they first become the role. 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This would only introduce a breaking change for people who override the AddRole Method in custom roles

**Other information**:
N/A
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
