### PR TITLE
InteractingScp330.cs: Reduction of bloat code from original design.

### DIFF
--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -22,5 +22,8 @@ jobs:
         sync-labels: true
   assign-author:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
@@ -39,6 +39,9 @@ namespace Exiled.Events.Patches.Events.Scp330
 
             LocalBuilder ev = generator.DeclareLocal(typeof(InteractingScp330EventArgs));
 
+            // Remove original "No scp can touch" logic.
+            newInstructions.RemoveRange(0, 3);
+
             // Find ServerProcessPickup, insert before it.
             int offset = -3;
             int index = newInstructions.FindLastIndex(

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
@@ -10,18 +10,12 @@ namespace Exiled.Events.Patches.Events.Scp330
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using API.Features.Pools;
-
-    using CustomPlayerEffects;
+    using Exiled.API.Features.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Scp330;
     using Exiled.Events.Handlers;
-
     using HarmonyLib;
-
     using Interactables.Interobjects;
-
-    using InventorySystem;
     using InventorySystem.Items.Usables.Scp330;
 
     using static HarmonyLib.AccessTools;
@@ -44,9 +38,6 @@ namespace Exiled.Events.Patches.Events.Scp330
             Label returnLabel = generator.DefineLabel();
 
             LocalBuilder ev = generator.DeclareLocal(typeof(InteractingScp330EventArgs));
-
-            // Remove original "No scp can touch" logic.
-            newInstructions.RemoveRange(0, 3);
 
             // Find ServerProcessPickup, insert before it.
             int offset = -3;
@@ -79,69 +70,25 @@ namespace Exiled.Events.Patches.Events.Scp330
                     new(OpCodes.Brfalse, returnLabel),
                 });
 
-            // Logic to find the only ServerProcessPickup and replace with our own.
-            int removeServerProcessOffset = -2;
-            int removeServerProcessIndex = newInstructions.FindLastIndex(
-                instruction => instruction.Calls(Method(typeof(Scp330Bag), nameof(Scp330Bag.ServerProcessPickup)))) + removeServerProcessOffset;
-
-            newInstructions.RemoveRange(removeServerProcessIndex, 3);
-
-            // Replace NW server process logic.
-            newInstructions.InsertRange(
-                removeServerProcessIndex,
-                new[]
-                {
-                    // ldarg.1 is already in the stack
-
-                    // ev.Candy
-                    new CodeInstruction(OpCodes.Ldloc, ev),
-                    new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(InteractingScp330EventArgs), nameof(InteractingScp330EventArgs.Candy))),
-
-                    // bag
-                    new CodeInstruction(OpCodes.Ldloca_S, 3),
-
-                    // ServerProcessPickup(ReferenceHub, CandyKindID, Scp330Bag)
-                    new CodeInstruction(OpCodes.Call, Method(typeof(InteractingScp330), nameof(ServerProcessPickup), new[] { typeof(ReferenceHub), typeof(CandyKindID), typeof(Scp330Bag).MakeByRefType() })),
-                });
-
             // This is to find the location of RpcMakeSound to remove the original code and add a new sever logic structure (Start point)
             int addShouldSeverOffset = 1;
             int addShouldSeverIndex = newInstructions.FindLastIndex(
                 instruction => instruction.Calls(Method(typeof(Scp330Interobject), nameof(Scp330Interobject.RpcMakeSound)))) + addShouldSeverOffset;
 
-            // This is to find the location of the next return (End point)
-            int includeSameLine = 1;
-            int nextReturn = newInstructions.FindIndex(addShouldSeverIndex, instruction => instruction.opcode == OpCodes.Ret) + includeSameLine;
-            Label originalLabel = newInstructions[addShouldSeverIndex].ExtractLabels()[0];
-
-            // Remove original code from after RpcMakeSound to next return and then fully replace it.
-            newInstructions.RemoveRange(addShouldSeverIndex, nextReturn - addShouldSeverIndex);
-
-            addShouldSeverIndex = newInstructions.FindLastIndex(
-                instruction => instruction.Calls(Method(typeof(Scp330Interobject), nameof(Scp330Interobject.RpcMakeSound)))) + addShouldSeverOffset;
+            int serverEffectLocationStart = -1;
+            int enableEffect = newInstructions.FindLastIndex(
+                instruction => instruction.LoadsField(Field(typeof(PlayerEffectsController), nameof(ReferenceHub.playerEffectsController)))) + serverEffectLocationStart;
 
             newInstructions.InsertRange(
                 addShouldSeverIndex,
-                new CodeInstruction[]
+                new[]
                 {
                     // if (!ev.ShouldSever)
                     //    goto shouldNotSever;
-                    new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex).WithLabels(originalLabel),
+                    new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(InteractingScp330EventArgs), nameof(InteractingScp330EventArgs.ShouldSever))),
                     new(OpCodes.Brfalse, shouldNotSever),
-
-                    // ev.Player.EnableEffect("SevereHands", 1, 0f, false)
-                    new(OpCodes.Ldloc, ev.LocalIndex),
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(InteractingScp330EventArgs), nameof(InteractingScp330EventArgs.Player))),
-                    new(OpCodes.Ldstr, nameof(SeveredHands)),
-                    new(OpCodes.Ldc_I4_1),
-                    new(OpCodes.Ldc_R4, 0f),
-                    new(OpCodes.Ldc_I4_0),
-                    new(OpCodes.Callvirt, Method(typeof(Player), nameof(Player.EnableEffect), new[] { typeof(string), typeof(byte), typeof(float), typeof(bool) })),
-                    new(OpCodes.Pop),
-
-                    // return;
-                    new(OpCodes.Ret),
+                    new(OpCodes.Br, enableEffect),
                 });
 
             // This will let us jump to the taken candies code and lock until ldarg_0, meaning we allow base game logic handle candy adding.
@@ -156,29 +103,6 @@ namespace Exiled.Events.Patches.Events.Scp330
                 yield return newInstructions[z];
 
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
-        }
-
-        private static bool ServerProcessPickup(ReferenceHub player, CandyKindID candy, out Scp330Bag bag)
-        {
-            if (!Scp330Bag.TryGetBag(player, out bag))
-            {
-                player.inventory.ServerAddItem(ItemType.SCP330);
-
-                if (!Scp330Bag.TryGetBag(player, out bag))
-                    return false;
-
-                bag.Candies = new List<CandyKindID> { candy };
-                bag.ServerRefreshBag();
-
-                return true;
-            }
-
-            bool result = bag.TryAddSpecific(candy);
-
-            if (bag.AcquisitionAlreadyReceived)
-                bag.ServerRefreshBag();
-
-            return result;
         }
     }
 }


### PR DESCRIPTION
## Description
Same behavior, less bloat, except for the primary check:

 // Remove original "No scp can touch" logic.
            newInstructions.RemoveRange(0, 3);

	if (!ply.IsHuman() || ply.HasBlock(BlockedInteraction.GrabItems))
	{
		return;
	}

	
That has been returned, presuming the client won't even send the request if it's not a human. If this behavior should be re-introduced, just add the RemoveRange back.

**What is the current behavior?** (You can also link to an open issue here)
Works fine, redundant code - SCP changed since original design. 

**What is the new behavior?** (if this is a feature change)
In theory same behavior. 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected - side bar, even with previous behavior, if force re-spawning with RA, user loses hand on first attempt - bug? Unsure, behavior seems to be the same nonetheless.

### Patches (if there are any changes related to Harmony patches)
- [X] I have checked no IL patching errors in the console
- 
![image](https://github.com/user-attachments/assets/fbc985cd-1092-4b05-8a77-9a6a6b82727b)


### Other
- [X] Still requires more testing - ¯\_(ツ)_/¯


If there is a desire to ensure nwapi behavior is kept:
`
if (playerInteractScp330Event.AllowPunishment && num2 >= 2)
`
Remove: `new(OpCodes.Br, enableEffect),`

Which will cause the the NW logic to occur. Otherwise, this will jump straight to

`ply.playerEffectsController.EnableEffect<SeveredHands>(0f, false);`

