### PR TITLE
Fix Friendly Fire rules

### DIFF
--- a/EXILED/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
+++ b/EXILED/Exiled.Events/Patches/Generic/IndividualFriendlyFire.cs
@@ -89,7 +89,7 @@ namespace Exiled.Events.Patches.Generic
 
             // Return false, no custom friendly fire allowed, default to NW logic for FF. No point in processing if FF is enabled across the board.
             if (Server.FriendlyFire)
-                return HitboxIdentity.IsEnemy(attackerFootprint.Role, victimHub.roleManager.CurrentRole.RoleTypeId);
+                return HitboxIdentity.IsDamageable(attackerFootprint.Role, victimHub.roleManager.CurrentRole.RoleTypeId);
 
             // always allow damage from Server.Host
             if (attackerFootprint.Hub == Server.Host.ReferenceHub)


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes `CheckFriendlyFirePlayerRules` to account for when Friendly Fire is enabled

**What is the current behavior?** (You can also link to an open issue here)
https://discord.com/channels/656673194693885975/1269192577475674213

**What is the new behavior?** (if this is a feature change)
Friendly Fire rules are respected.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. Only thing that will change is that Friendly Fire servers will be able to flash their teammates as they are supposed to be able to in base-game. (Just like grenades)

**Other information**:
I could possibly just return true instead of `HitboxIdentity.IsDamageable` as it would immediately return true anyways when FriendlyFire is enabled. 
Could also replace calls to `Server.FriendlyFire || CheckFriendlyFirePlayerRules` with just `CheckFriendlyFirePlayerRules`, but that is up to you.

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
