### PR TITLE
Interacting scp330 compile fix

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
@@ -80,7 +80,7 @@ namespace Exiled.Events.Patches.Events.Scp330
 
             int serverEffectLocationStart = -1;
             int enableEffect = newInstructions.FindLastIndex(
-                instruction => instruction.LoadsField(Field(typeof(PlayerEffectsController), nameof(ReferenceHub.playerEffectsController)))) + serverEffectLocationStart;
+                instruction => instruction.LoadsField(Field(typeof(ReferenceHub), nameof(ReferenceHub.playerEffectsController)))) + serverEffectLocationStart;
 
             newInstructions.InsertRange(
                 addShouldSeverIndex,

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
@@ -26,7 +26,7 @@ namespace Exiled.Events.Patches.Events.Scp330
     /// Patches the <see cref="Scp330Interobject.ServerInteract(ReferenceHub, byte)" /> method to add the
     /// <see cref="Scp330.InteractingScp330" /> event.
     /// </summary>
-    // [EventPatch(typeof(Scp330), nameof(Scp330.InteractingScp330))]
+    [EventPatch(typeof(Scp330), nameof(Scp330.InteractingScp330))]
     [HarmonyPatch(typeof(Scp330Interobject), nameof(Scp330Interobject.ServerInteract))]
     public static class InteractingScp330
     {

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
@@ -26,7 +26,7 @@ namespace Exiled.Events.Patches.Events.Scp330
     /// Patches the <see cref="Scp330Interobject.ServerInteract(ReferenceHub, byte)" /> method to add the
     /// <see cref="Scp330.InteractingScp330" /> event.
     /// </summary>
-    [EventPatch(typeof(Scp330), nameof(Scp330.InteractingScp330))]
+    // [EventPatch(typeof(Scp330), nameof(Scp330.InteractingScp330))]
     [HarmonyPatch(typeof(Scp330Interobject), nameof(Scp330Interobject.ServerInteract))]
     public static class InteractingScp330
     {
@@ -36,6 +36,7 @@ namespace Exiled.Events.Patches.Events.Scp330
 
             Label shouldNotSever = generator.DefineLabel();
             Label returnLabel = generator.DefineLabel();
+            Label enableEffectLabel = generator.DefineLabel();
 
             LocalBuilder ev = generator.DeclareLocal(typeof(InteractingScp330EventArgs));
 
@@ -74,14 +75,14 @@ namespace Exiled.Events.Patches.Events.Scp330
                 });
 
             // This is to find the location of RpcMakeSound to remove the original code and add a new sever logic structure (Start point)
-            int addShouldSeverOffset = 1;
+            int addShouldSeverOffset = -1;
             int addShouldSeverIndex = newInstructions.FindLastIndex(
                 instruction => instruction.Calls(Method(typeof(Scp330Interobject), nameof(Scp330Interobject.RpcMakeSound)))) + addShouldSeverOffset;
 
             int serverEffectLocationStart = -1;
             int enableEffect = newInstructions.FindLastIndex(
                 instruction => instruction.LoadsField(Field(typeof(ReferenceHub), nameof(ReferenceHub.playerEffectsController)))) + serverEffectLocationStart;
-
+            newInstructions[enableEffect].WithLabels(enableEffectLabel);
             newInstructions.InsertRange(
                 addShouldSeverIndex,
                 new[]
@@ -91,7 +92,7 @@ namespace Exiled.Events.Patches.Events.Scp330
                     new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(InteractingScp330EventArgs), nameof(InteractingScp330EventArgs.ShouldSever))),
                     new(OpCodes.Brfalse, shouldNotSever),
-                    new(OpCodes.Br, enableEffect),
+                    new(OpCodes.Br, enableEffectLabel),
                 });
 
             // This will let us jump to the taken candies code and lock until ldarg_0, meaning we allow base game logic handle candy adding.


### PR DESCRIPTION
## Description
**Describe the changes** 
Skill issue (Or rather my scp server does not compile with error, for whatever reason).

**What is the current behavior?** (You can also link to an open issue here)
Compile bug

**What is the new behavior?** (if this is a feature change)
Interact event compiles correctly (I am going to assume Yamato double checked but someone else should too).

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
Yamato and I went back and forth on why my scp instance did not throw a compile error for this, but did for his pr that resolves a bug, no idea why. The only difference is windows versions, and system's themselves. Even built on his branch + changes I did not get a compile error or warning. Very weird (and yes I tried both debug and release build).

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled (Someone double check, my system for whatever reason even on a clean build did not complain, I have zero idea why)
- [] I have tested my changes and it worked as expected (See above).

### Patches (if there are any changes related to Harmony patches)
- [] I have checked no IL patching errors in the console (see above)
 
### Other
- [] Still requires more testing (see above)
