### PR TITLE
😱😎🙂💀😈

### DIFF
--- a/EXILED/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/MirrorExtensions.cs
@@ -363,6 +363,7 @@ namespace Exiled.API.Extensions
         /// <param name="targetType"><see cref="NetworkBehaviour"/>'s type.</param>
         /// <param name="propertyName">Property name starting with Network.</param>
         /// <param name="value">Value of send to target.</param>
+        [Obsolete("Use overload with type-template instead.")]
         public static void SendFakeSyncVar(this Player target, NetworkIdentity behaviorOwner, Type targetType, string propertyName, object value)
         {
             if (!target.IsConnected)
@@ -383,6 +384,38 @@ namespace Exiled.API.Extensions
             {
                 targetWriter.WriteULong(SyncVarDirtyBits[$"{targetType.Name}.{propertyName}"]);
                 WriterExtensions[value.GetType()]?.Invoke(null, new object[2] { targetWriter, value });
+            }
+        }
+
+        /// <summary>
+        /// Send fake values to client's <see cref="SyncVarAttribute"/>.
+        /// </summary>
+        /// <typeparam name="T">Target SyncVar property type.</typeparam>
+        /// <param name="target">Target to send.</param>
+        /// <param name="behaviorOwner"><see cref="NetworkIdentity"/> of object that owns <see cref="NetworkBehaviour"/>.</param>
+        /// <param name="targetType"><see cref="NetworkBehaviour"/>'s type.</param>
+        /// <param name="propertyName">Property name starting with Network.</param>
+        /// <param name="value">Value of send to target.</param>
+        public static void SendFakeSyncVar<T>(this Player target, NetworkIdentity behaviorOwner, Type targetType, string propertyName, T value)
+        {
+            if (!target.IsConnected)
+                return;
+
+            NetworkWriterPooled writer = NetworkWriterPool.Get();
+            NetworkWriterPooled writer2 = NetworkWriterPool.Get();
+            MakeCustomSyncWriter(behaviorOwner, targetType, null, CustomSyncVarGenerator, writer, writer2);
+            target.Connection.Send(new EntityStateMessage
+            {
+                netId = behaviorOwner.netId,
+                payload = writer.ToArraySegment(),
+            });
+
+            NetworkWriterPool.Return(writer);
+            NetworkWriterPool.Return(writer2);
+            void CustomSyncVarGenerator(NetworkWriter targetWriter)
+            {
+                targetWriter.WriteULong(SyncVarDirtyBits[$"{targetType.Name}.{propertyName}"]);
+                WriterExtensions[typeof(T)]?.Invoke(null, new object[2] { targetWriter, value });
             }
         }
 

--- a/EXILED/Exiled.Events/Patches/Generic/DoorList.cs
+++ b/EXILED/Exiled.Events/Patches/Generic/DoorList.cs
@@ -30,6 +30,11 @@ namespace Exiled.Events.Patches.Generic
     [HarmonyPatch(typeof(DoorVariant), nameof(DoorVariant.RegisterRooms))]
     internal class DoorList
     {
+        private static bool Prefix(DoorVariant __instance)
+        {
+            return __instance.Rooms == null;
+        }
+
         private static void Postfix(DoorVariant __instance)
         {
             if (Door.DoorVariantToDoor.ContainsKey(__instance))

--- a/EXILED/Exiled.Events/Patches/Generic/DoorList.cs
+++ b/EXILED/Exiled.Events/Patches/Generic/DoorList.cs
@@ -36,7 +36,8 @@ namespace Exiled.Events.Patches.Generic
 
             Label ret = generator.DefineLabel();
 
-            // new Generator(this)
+            // if (Rooms == null)
+            //     return;
             newInstructions.InsertRange(
                 0,
                 new CodeInstruction[]
@@ -46,6 +47,7 @@ namespace Exiled.Events.Patches.Generic
                     new(OpCodes.Brfalse_S, ret),
                 });
 
+            // DoorList.InitDoor(this);
             newInstructions.InsertRange(
                 newInstructions.Count - 1,
                 new CodeInstruction[]

--- a/EXILED/Exiled.Events/Patches/Generic/DoorList.cs
+++ b/EXILED/Exiled.Events/Patches/Generic/DoorList.cs
@@ -30,19 +30,46 @@ namespace Exiled.Events.Patches.Generic
     [HarmonyPatch(typeof(DoorVariant), nameof(DoorVariant.RegisterRooms))]
     internal class DoorList
     {
-        private static bool Prefix(DoorVariant __instance)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            return __instance.Rooms == null;
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            Label ret = generator.DefineLabel();
+
+            // new Generator(this)
+            newInstructions.InsertRange(
+                0,
+                new CodeInstruction[]
+                {
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(DoorVariant), nameof(DoorVariant.Rooms))),
+                    new(OpCodes.Brfalse_S, ret),
+                });
+
+            newInstructions.InsertRange(
+                newInstructions.Count - 1,
+                new CodeInstruction[]
+                {
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Call, Method(typeof(DoorList), nameof(DoorList.InitDoor))),
+                });
+
+            newInstructions[newInstructions.Count - 1].labels.Add(ret);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
         }
 
-        private static void Postfix(DoorVariant __instance)
+        private static void InitDoor(DoorVariant doorVariant)
         {
-            if (Door.DoorVariantToDoor.ContainsKey(__instance))
+            if (Door.DoorVariantToDoor.ContainsKey(doorVariant))
                 return;
 
-            List<Room> rooms = __instance.Rooms.Select(identifier => Room.RoomIdentifierToRoom[identifier]).ToList();
+            List<Room> rooms = doorVariant.Rooms.Select(identifier => Room.RoomIdentifierToRoom[identifier]).ToList();
 
-            Door door = Door.Create(__instance, rooms);
+            Door door = Door.Create(doorVariant, rooms);
 
             foreach (Room room in rooms)
             {


### PR DESCRIPTION
## Description
**Describe the changes** 
1. Fixes `DoorVariant::RegisterRooms` patch, that prefix condition was created by me earlier to prevent `DoorVariant::Rooms` being broken(by basegame code rooms will be empty, when register rooms more than once), but somehow it was deleted😭 (I discovered that bug for MER doors, but Im sure it can affect regular doors(al least it was before))
2. Added new overload for `SendFakeSyncVars`, for fixing sending `null` syncvars (for example sending `null` player custom info)

**What is the current behavior?** (You can also link to an open issue here)
rooms are not registered
syncvars throw nre
😭

**What is the new behavior?** (if this is a feature change)
rooms are registered
syncvars dont throw nre
😎

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No🥲

**Other information**:
Other information
Error that lead to break syncvars, was caused by `value.GetType`, when value is `null`, i created type-template method so type is not taken directly from the object, and you can send, for example, `null` strings
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console
![image](https://github.com/user-attachments/assets/100b51dd-c50f-463f-90e0-487398759ce4)

### Other
- [ ] Still requires more testing
