### PR TITLE
`[EXILED::EVENTS]` Fixing bug report n.396

### DIFF
--- a/EXILED/Exiled.Events/Patches/Fixes/NWFixDetonationTimer.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/NWFixDetonationTimer.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+// <copyright file="NWFixDetonationTimer.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+    using System;
+    using System.Linq;
+
+    using GameCore;
+    using HarmonyLib;
+
+    /// <summary>
+    /// Fixes the issue where the game was not selecting the scenario with the nearest <see cref="AlphaWarheadController.DetonationScenario.TimeToDetonate"/> value.
+    /// </summary>
+    [HarmonyPatch(typeof(AlphaWarheadController), nameof(AlphaWarheadController.Start))]
+    internal class NWFixDetonationTimer
+    {
+        private static void Postfix()
+        {
+            AlphaWarheadSyncInfo networkInfo = default;
+            networkInfo.ScenarioId = Array.IndexOf(AlphaWarheadController.Singleton._startScenarios, AlphaWarheadController.Singleton._startScenarios.OrderBy(d => Math.Abs(d.TimeToDetonate - ConfigFile.ServerConfig.GetInt("warhead_tminus_start_duration", 90))).First());
+
+            AlphaWarheadController.Singleton.NetworkInfo = networkInfo;
+            return;
+        }
+    }
+}

--- a/EXILED/Exiled.Events/Patches/Fixes/NWFixDetonationTimer.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/NWFixDetonationTimer.cs
@@ -15,6 +15,7 @@ namespace Exiled.Events.Patches.Fixes
 
     /// <summary>
     /// Fixes the issue where the game was not selecting the scenario with the nearest <see cref="AlphaWarheadController.DetonationScenario.TimeToDetonate"/> value.
+    /// <a href="https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/396">Bug Report</a>
     /// </summary>
     [HarmonyPatch(typeof(AlphaWarheadController), nameof(AlphaWarheadController.Start))]
     internal class NWFixDetonationTimer


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/396

**What is the current behavior?** (You can also link to an open issue here)
Games just takes the first Scenario, 120 seconds and just uses that if the value is not the same as one of the scenarios
![immagine](https://github.com/user-attachments/assets/78678b7e-b58b-46b3-870f-9d42444ad0ce)

**What is the new behavior?** (if this is a feature change)
Takes the nearest number from the Scene loaded from the game
![immagine](https://github.com/user-attachments/assets/21e465f8-7791-47a9-bcd5-7aaa6a94629b)

Just as it showing i replicated the issue from the report but fixing it and showing the default game behavior

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Shouldn't
(I've checked if in the config or in some way is changed but doesn't seem)

**Other information**:
The code is big and a mess because SL doesn't let me change directly the network info so i need to take the default one and then change it and forgot to say that SL has no value for the configfile so i took it manually

![immagine](https://github.com/user-attachments/assets/f83e3e90-3656-4f27-bdfb-bc7168e17549)
Like im showing here the game does that


(Not 100% this works i didn't test it in game to see if the cassie replies correctly but it seems ok by showing)
![immagine](https://github.com/user-attachments/assets/bce5c21d-d28a-4de0-8df4-c77077d064df)

This shows how the Logs where done
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
