### PR TITLE
`[Exiled::API]` New way to register parent commands

### DIFF
--- a/EXILED/Exiled.API/Features/Plugin.cs
+++ b/EXILED/Exiled.API/Features/Plugin.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.API.Features
 {
+    using System.Linq;
+
 #pragma warning disable SA1402
     using System;
     using System.Collections.Generic;
@@ -97,6 +99,8 @@ namespace Exiled.API.Features
         /// <inheritdoc/>
         public virtual void OnRegisteringCommands()
         {
+            Dictionary<Type, List<Type>> toRegister = new();
+
             foreach (Type type in Assembly.GetTypes())
             {
                 if (type.GetInterface("ICommand") != typeof(ICommand))
@@ -105,28 +109,42 @@ namespace Exiled.API.Features
                 if (!Attribute.IsDefined(type, typeof(CommandHandlerAttribute)))
                     continue;
 
-                foreach (CustomAttributeData customAttributeData in type.CustomAttributes)
+                foreach (CustomAttributeData customAttributeData in type.GetCustomAttributesData())
                 {
                     try
                     {
                         if (customAttributeData.AttributeType != typeof(CommandHandlerAttribute))
                             continue;
 
-                        Type commandType = (Type)customAttributeData.ConstructorArguments?[0].Value;
+                        Type commandHandlerType = (Type)customAttributeData.ConstructorArguments[0].Value;
 
-                        if (!Commands.TryGetValue(commandType, out Dictionary<Type, ICommand> typeCommands))
+                        ICommand command = GetCommand(type) ?? (ICommand)Activator.CreateInstance(type);
+
+                        if (typeof(ParentCommand).IsAssignableFrom(commandHandlerType))
+                        {
+                            ParentCommand parentCommand = GetCommand(commandHandlerType) as ParentCommand;
+
+                            if (parentCommand == null)
+                            {
+                                if (!toRegister.TryGetValue(commandHandlerType, out List<Type> list))
+                                    toRegister.Add(commandHandlerType, new() { type });
+                                else
+                                    list.Add(type);
+
+                                continue;
+                            }
+
+                            parentCommand.RegisterCommand(command);
                             continue;
-
-                        if (!typeCommands.TryGetValue(type, out ICommand command))
-                            command = (ICommand)Activator.CreateInstance(type);
+                        }
 
                         try
                         {
-                            if (commandType == typeof(RemoteAdminCommandHandler))
+                            if (commandHandlerType == typeof(RemoteAdminCommandHandler))
                                 CommandProcessor.RemoteAdminCommandHandler.RegisterCommand(command);
-                            else if (commandType == typeof(GameConsoleCommandHandler))
+                            else if (commandHandlerType == typeof(GameConsoleCommandHandler))
                                 GameCore.Console.singleton.ConsoleCommandHandler.RegisterCommand(command);
-                            else if (commandType == typeof(ClientCommandHandler))
+                            else if (commandHandlerType == typeof(ClientCommandHandler))
                                 QueryProcessor.DotCommandHandler.RegisterCommand(command);
                         }
                         catch (ArgumentException e)
@@ -141,7 +159,7 @@ namespace Exiled.API.Features
                             }
                         }
 
-                        Commands[commandType][type] = command;
+                        Commands[commandHandlerType][type] = command;
                     }
                     catch (Exception exception)
                     {
@@ -149,6 +167,39 @@ namespace Exiled.API.Features
                     }
                 }
             }
+
+            foreach (KeyValuePair<Type, List<Type>> kvp in toRegister)
+            {
+                ParentCommand parentCommand = GetCommand(kvp.Key) as ParentCommand;
+
+                foreach (Type type in kvp.Value)
+                    parentCommand.RegisterCommand((ICommand)Activator.CreateInstance(type));
+            }
+        }
+
+        /// <summary>
+        /// Gets a command by it's type.
+        /// </summary>
+        /// <param name="type"><see cref="ICommand"/>'s type.</param>
+        /// <param name="commandHandler"><see cref="CommandHandler"/>'s type. Defines in which command handler command is registered.</param>
+        /// <returns>A <see cref="ICommand"/>. May be <see langword="null"/> if command is not registered.</returns>
+        public ICommand GetCommand(Type type, Type commandHandler = null)
+        {
+            if (type.GetInterface("ICommand") != typeof(ICommand))
+                return null;
+
+            if (commandHandler != null)
+            {
+                if (!Commands.TryGetValue(commandHandler, out Dictionary<Type, ICommand> commands))
+                    return null;
+
+                if (!commands.TryGetValue(type, out ICommand command))
+                    return null;
+
+                return command;
+            }
+
+            return Commands.Keys.Select(commandHandlerType => GetCommand(type, commandHandlerType)).FirstOrDefault(command => command != null);
         }
 
         /// <inheritdoc/>

--- a/EXILED/Exiled.API/Features/Plugin.cs
+++ b/EXILED/Exiled.API/Features/Plugin.cs
@@ -99,7 +99,7 @@ namespace Exiled.API.Features
         /// <inheritdoc/>
         public virtual void OnRegisteringCommands()
         {
-            Dictionary<Type, List<Type>> toRegister = new();
+            Dictionary<Type, List<ICommand>> toRegister = new();
 
             foreach (Type type in Assembly.GetTypes())
             {
@@ -126,10 +126,10 @@ namespace Exiled.API.Features
 
                             if (parentCommand == null)
                             {
-                                if (!toRegister.TryGetValue(commandHandlerType, out List<Type> list))
-                                    toRegister.Add(commandHandlerType, new() { type });
+                                if (!toRegister.TryGetValue(commandHandlerType, out List<ICommand> list))
+                                    toRegister.Add(commandHandlerType, new() { command });
                                 else
-                                    list.Add(type);
+                                    list.Add(command);
 
                                 continue;
                             }
@@ -168,12 +168,12 @@ namespace Exiled.API.Features
                 }
             }
 
-            foreach (KeyValuePair<Type, List<Type>> kvp in toRegister)
+            foreach (KeyValuePair<Type, List<ICommand>> kvp in toRegister)
             {
                 ParentCommand parentCommand = GetCommand(kvp.Key) as ParentCommand;
 
-                foreach (Type type in kvp.Value)
-                    parentCommand.RegisterCommand((ICommand)Activator.CreateInstance(type));
+                foreach (ICommand command in kvp.Value)
+                    parentCommand.RegisterCommand(command);
             }
         }
 

--- a/EXILED/Exiled.Events/Commands/Config/EConfig.cs
+++ b/EXILED/Exiled.Events/Commands/Config/EConfig.cs
@@ -17,14 +17,6 @@ namespace Exiled.Events.Commands.Config
     [CommandHandler(typeof(GameConsoleCommandHandler))]
     public class EConfig : ParentCommand
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EConfig"/> class.
-        /// </summary>
-        public EConfig()
-        {
-            LoadGeneratedCommands();
-        }
-
         /// <inheritdoc/>
         public override string Command { get; } = "econfig";
 
@@ -37,8 +29,6 @@ namespace Exiled.Events.Commands.Config
         /// <inheritdoc/>
         public override void LoadGeneratedCommands()
         {
-            RegisterCommand(Merge.Instance);
-            RegisterCommand(Split.Instance);
         }
 
         /// <inheritdoc/>

--- a/EXILED/Exiled.Events/Commands/Config/Merge.cs
+++ b/EXILED/Exiled.Events/Commands/Config/Merge.cs
@@ -20,6 +20,7 @@ namespace Exiled.Events.Commands.Config
     /// <summary>
     /// The config merge command.
     /// </summary>
+    [CommandHandler(typeof(EConfig))]
     public class Merge : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Config/Split.cs
+++ b/EXILED/Exiled.Events/Commands/Config/Split.cs
@@ -20,6 +20,7 @@ namespace Exiled.Events.Commands.Config
     /// <summary>
     /// The config split command.
     /// </summary>
+    [CommandHandler(typeof(EConfig))]
     public class Split : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/PluginManager/Disable.cs
+++ b/EXILED/Exiled.Events/Commands/PluginManager/Disable.cs
@@ -17,6 +17,7 @@ namespace Exiled.Events.Commands.PluginManager
     /// <summary>
     /// The command to disable a plugin.
     /// </summary>
+    [CommandHandler(typeof(PluginManager))]
     public sealed class Disable : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/PluginManager/Enable.cs
+++ b/EXILED/Exiled.Events/Commands/PluginManager/Enable.cs
@@ -21,6 +21,7 @@ namespace Exiled.Events.Commands.PluginManager
     /// <summary>
     /// The command to enable a plugin.
     /// </summary>
+    [CommandHandler(typeof(PluginManager))]
     public sealed class Enable : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/PluginManager/Patches.cs
+++ b/EXILED/Exiled.Events/Commands/PluginManager/Patches.cs
@@ -23,6 +23,7 @@ namespace Exiled.Events.Commands.PluginManager
     /// <summary>
     /// The command to show all the patches done by plugins.
     /// </summary>
+    [CommandHandler(typeof(PluginManager))]
     public sealed class Patches : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/PluginManager/PluginManager.cs
+++ b/EXILED/Exiled.Events/Commands/PluginManager/PluginManager.cs
@@ -18,14 +18,6 @@ namespace Exiled.Events.Commands.PluginManager
     [CommandHandler(typeof(GameConsoleCommandHandler))]
     public class PluginManager : ParentCommand
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PluginManager"/> class.
-        /// </summary>
-        public PluginManager()
-        {
-            LoadGeneratedCommands();
-        }
-
         /// <inheritdoc/>
         public override string Command { get; } = "pluginmanager";
 
@@ -38,10 +30,6 @@ namespace Exiled.Events.Commands.PluginManager
         /// <inheritdoc/>
         public override void LoadGeneratedCommands()
         {
-            RegisterCommand(Show.Instance);
-            RegisterCommand(Enable.Instance);
-            RegisterCommand(Disable.Instance);
-            RegisterCommand(Patches.Instance);
         }
 
         /// <inheritdoc/>

--- a/EXILED/Exiled.Events/Commands/PluginManager/Show.cs
+++ b/EXILED/Exiled.Events/Commands/PluginManager/Show.cs
@@ -24,6 +24,7 @@ namespace Exiled.Events.Commands.PluginManager
     /// <summary>
     /// The command to show all plugins.
     /// </summary>
+    [CommandHandler(typeof(PluginManager))]
     public sealed class Show : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/All.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/All.cs
@@ -14,6 +14,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload all command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class All : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/Configs.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/Configs.cs
@@ -20,6 +20,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload configs command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class Configs : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/GamePlay.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/GamePlay.cs
@@ -18,6 +18,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload gameplay command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class GamePlay : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/Permissions.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/Permissions.cs
@@ -17,6 +17,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload permissions command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class Permissions : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/Plugins.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/Plugins.cs
@@ -19,6 +19,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload plugins command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class Plugins : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/Reload.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/Reload.cs
@@ -18,14 +18,6 @@ namespace Exiled.Events.Commands.Reload
     [CommandHandler(typeof(GameConsoleCommandHandler))]
     public class Reload : ParentCommand
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Reload"/> class.
-        /// </summary>
-        public Reload()
-        {
-            LoadGeneratedCommands();
-        }
-
         /// <inheritdoc/>
         public override string Command { get; } = "reload";
 
@@ -38,13 +30,6 @@ namespace Exiled.Events.Commands.Reload
         /// <inheritdoc/>
         public override void LoadGeneratedCommands()
         {
-            RegisterCommand(All.Instance);
-            RegisterCommand(Configs.Instance);
-            RegisterCommand(Translations.Instance);
-            RegisterCommand(Plugins.Instance);
-            RegisterCommand(GamePlay.Instance);
-            RegisterCommand(RemoteAdmin.Instance);
-            RegisterCommand(Permissions.Instance);
         }
 
         /// <inheritdoc/>

--- a/EXILED/Exiled.Events/Commands/Reload/RemoteAdmin.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/RemoteAdmin.cs
@@ -18,6 +18,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload remoteadmin command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class RemoteAdmin : ICommand
     {
         /// <summary>

--- a/EXILED/Exiled.Events/Commands/Reload/Translations.cs
+++ b/EXILED/Exiled.Events/Commands/Reload/Translations.cs
@@ -20,6 +20,7 @@ namespace Exiled.Events.Commands.Reload
     /// <summary>
     /// The reload translations command.
     /// </summary>
+    [CommandHandler(typeof(Reload))]
     public class Translations : ICommand
     {
         /// <summary>


### PR DESCRIPTION
## Description
**Describe the changes** 
Adding a new way to register commands for parent commands. Iirc this is system which is similar to nw

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
No breaking changes cuz both systems are supported (new and current)
~(but for me this is better)~

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing (i would like if someone else will also test it)
