### PR TITLE
Allow `ID_Dedicated`/`null` for `Npc.UserId` Parameter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,29 +13,28 @@ Scripts: # Add the 'Scripts' label
 
 regarding-events: # Add the 'Events' label
 - changed-files:
-  - any-glob-to-any-file: Exiled.Events/** # Any Modifications to events
+  - any-glob-to-any-file: EXILED/Exiled.Events/** # Any Modifications to events
 
 regarding-api: # Add the 'API' label
 - changed-files:
-  - any-glob-to-any-file: Exiled.API/** # Any modifications to the API
+  - any-glob-to-any-file: EXILED/Exiled.API/** # Any modifications to the API
 
 regarding-transpiler: # Add the 'transpiler' label
 - changed-files:
-  - any-glob-to-any-file: Exiled.Events/Patches/**/* # Any modifications to transpiler files
+  - any-glob-to-any-file: EXILED/Exiled.Events/Patches/**/* # Any modifications to transpiler files
 
 CustomModules: # Add the 'CustomModules' label
 - changed-files:
-  - any-glob-to-any-file: Exiled.CustomModules/** # Any modifications to CustomModules
+  - any-glob-to-any-file: EXILED/Exiled.CustomModules/** # Any modifications to CustomModules
 
 Installer: # Add the 'Installer' label
 - changed-files:
-  - any-glob-to-any-file: Exiled.Installer/** # Any modifications to the Installer
+  - any-glob-to-any-file: EXILED/Exiled.Installer/** # Any modifications to the Installer
 
 Localization: # Add the 'Localization' label
 - changed-files:
-  - any-glob-to-any-file: Localization/** # Any modifications to Localization
+  - any-glob-to-any-file: EXILED/Localization/** # Any modifications to Localization
 
 GitHub_Actions: # Add the 'GitHub' label
 - changed-files:
   - any-glob-to-any-file: .github/** # Any modifications to github related files
-

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -193,7 +193,7 @@ namespace Exiled.API.Features
                 npc.Role.Set(role, SpawnReason.RoundStart, position is null ? RoleSpawnFlags.All : RoleSpawnFlags.AssignInventory);
 
                 if (position is not null)
-                    npc.Position = position.Value
+                    npc.Position = position.Value;
             });
 
             return npc;

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -191,10 +191,10 @@ namespace Exiled.API.Features
             Timing.CallDelayed(0.5f, () =>
             {
                 npc.Role.Set(role, SpawnReason.RoundStart, position is null ? RoleSpawnFlags.All : RoleSpawnFlags.AssignInventory);
-            });
 
-            if (position is not null)
-                Timing.CallDelayed(0.5f, () => npc.Position = position.Value);
+                if (position is not null)
+                    npc.Position = position.Value
+            });
 
             return npc;
         }

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -11,7 +11,8 @@ namespace Exiled.API.Features
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using System.Reflection;
+    using CentralAuth;
     using CommandSystem;
 
     using Exiled.API.Enums;
@@ -134,11 +135,13 @@ namespace Exiled.API.Features
         public static Npc Spawn(string name, RoleTypeId role, int id = 0, string userId = "", Vector3? position = null)
         {
             GameObject newObject = Object.Instantiate(NetworkManager.singleton.playerPrefab);
+
             Npc npc = new(newObject)
             {
-                IsVerified = true,
+                IsVerified = userId != PlayerAuthenticationManager.DedicatedId && userId != null,
                 IsNPC = true,
             };
+
             try
             {
                 npc.ReferenceHub.roleManager.InitializeNewRole(RoleTypeId.None, RoleChangeReason.None);
@@ -148,20 +151,33 @@ namespace Exiled.API.Features
                 Log.Debug($"Ignore: {e}");
             }
 
-            if (RecyclablePlayerId.FreeIds.Contains(id))
+            if (!RecyclablePlayerId.FreeIds.Contains(id) && RecyclablePlayerId._autoIncrement >= id)
             {
-                RecyclablePlayerId.FreeIds.RemoveFromQueue(id);
-            }
-            else if (RecyclablePlayerId._autoIncrement >= id)
-            {
-                RecyclablePlayerId._autoIncrement = id = RecyclablePlayerId._autoIncrement + 1;
+                Log.Warn($"{Assembly.GetCallingAssembly().GetName().Name} tried to spawn an NPC with a duplicate PlayerID. Using auto-incremented ID instead to avoid issues.");
+                id = new RecyclablePlayerId(false).Value;
             }
 
             FakeConnection fakeConnection = new(id);
             NetworkServer.AddPlayerForConnection(fakeConnection, newObject);
+
             try
             {
-                npc.ReferenceHub.authManager.UserId = string.IsNullOrEmpty(userId) ? $"Dummy@localhost" : userId;
+                if (userId == PlayerAuthenticationManager.DedicatedId)
+                {
+                    npc.ReferenceHub.authManager.SyncedUserId = userId;
+                    try
+                    {
+                        npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.DedicatedServer;
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Debug($"Ignore: {e}");
+                    }
+                }
+                else
+                {
+                    npc.ReferenceHub.authManager.UserId = userId == string.Empty ? $"Dummy@localhost" : userId;
+                }
             }
             catch (Exception e)
             {
@@ -171,15 +187,14 @@ namespace Exiled.API.Features
             npc.ReferenceHub.nicknameSync.Network_myNickSync = name;
             Dictionary.Add(newObject, npc);
 
-            Timing.CallDelayed(
-                0.3f,
-                () =>
-                {
-                    npc.Role.Set(role, SpawnReason.RoundStart, position is null ? RoleSpawnFlags.All : RoleSpawnFlags.AssignInventory);
-                });
+            Timing.CallDelayed(0.5f, () =>
+            {
+                npc.Role.Set(role, SpawnReason.RoundStart, position is null ? RoleSpawnFlags.All : RoleSpawnFlags.AssignInventory);
+            });
 
             if (position is not null)
                 Timing.CallDelayed(0.5f, () => npc.Position = position.Value);
+
             return npc;
         }
 

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -164,7 +164,8 @@ namespace Exiled.API.Features
                 }
                 else
                 {
-                    npc.ReferenceHub.authManager.UserId = userId == string.Empty ? $"Dummy@localhost" : userId;
+                    npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.Unverified;
+                    npc.ReferenceHub.authManager._privUserId = userId == string.Empty ? $"Dummy@localhost" : userId;
                 }
             }
             catch (Exception e)

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -145,7 +145,7 @@ namespace Exiled.API.Features
             if (!RecyclablePlayerId.FreeIds.Contains(id) && RecyclablePlayerId._autoIncrement >= id)
             {
                 Log.Warn($"{Assembly.GetCallingAssembly().GetName().Name} tried to spawn an NPC with a duplicate PlayerID. Using auto-incremented ID instead to avoid an ID clash.");
-                id = new RecyclablePlayerId(false).Value;
+                id = new RecyclablePlayerId(true).Value;
             }
 
             try

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+
     using CentralAuth;
     using CommandSystem;
 


### PR DESCRIPTION
## Description
**Describe the changes** 
Use `ID_Dedicated` or `null` to ensure an NPC is VSR Compliant (Uses Unverified/DedicatedHost instances, which will not take up slots or show on the Player List)

**What is the current behavior?** (You can also link to an open issue here)
None

**What is the new behavior?** (if this is a feature change)
None

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
Original PR Done in the previous repo and imported inside apis-rework as asked by the suggestion i added it back and made it available for the next versions of Exiled

https://github.com/Exiled-Team/EXILED/pull/2297

I stripped the other functionality

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
