### PR TITLE
``[Exiled::CustomRoles]`` ``[Exiled::CustomItems]`` QoL in List commands.

### DIFF
--- a/EXILED/Exiled.CustomItems/Commands/List/List.cs
+++ b/EXILED/Exiled.CustomItems/Commands/List/List.cs
@@ -48,7 +48,7 @@ namespace Exiled.CustomItems.Commands.List
             if (arguments.IsEmpty() && TryGetCommand(Registered.Instance.Command, out ICommand command))
             {
                 command.Execute(arguments, sender, out response);
-                response = string.Join(response, $"\nTo view custom items in players' inventories, use the command: {arguments.Array[0]} {arguments.Array[1]} insideinventories");
+                response += $"\nTo view custom items in players' inventories, use the command: {string.Join(" ", arguments.Array)} insideinventories";
                 return true;
             }
 

--- a/EXILED/Exiled.CustomItems/Commands/List/List.cs
+++ b/EXILED/Exiled.CustomItems/Commands/List/List.cs
@@ -45,7 +45,14 @@ namespace Exiled.CustomItems.Commands.List
         /// <inheritdoc/>
         protected override bool ExecuteParent(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            response = $"Invalid subcommand! Available: registered, insideinventories";
+            if (arguments.IsEmpty() && TryGetCommand(Registered.Instance.Command, out ICommand command))
+            {
+                command.Execute(arguments, sender, out response);
+                response += $"\nTo view custom items in players' inventories, use the command: {arguments.Array[0]} {arguments.Array[1]} insideinventories";
+                return true;
+            }
+
+            response = "Invalid subcommand! Available: registered, insideinventories";
             return false;
         }
     }

--- a/EXILED/Exiled.CustomItems/Commands/List/List.cs
+++ b/EXILED/Exiled.CustomItems/Commands/List/List.cs
@@ -48,7 +48,7 @@ namespace Exiled.CustomItems.Commands.List
             if (arguments.IsEmpty() && TryGetCommand(Registered.Instance.Command, out ICommand command))
             {
                 command.Execute(arguments, sender, out response);
-                response += $"\nTo view custom items in players' inventories, use the command: {arguments.Array[0]} {arguments.Array[1]} insideinventories";
+                response = string.Join(response, $"\nTo view custom items in players' inventories, use the command: {arguments.Array[0]} {arguments.Array[1]} insideinventories");
                 return true;
             }
 

--- a/EXILED/Exiled.CustomRoles/Commands/List/List.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/List/List.cs
@@ -45,7 +45,14 @@ namespace Exiled.CustomRoles.Commands.List
         /// <inheritdoc/>
         protected override bool ExecuteParent(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            response = "Invalid subcommand! Available: registered.";
+            if (arguments.IsEmpty() && TryGetCommand(Registered.Instance.Command, out ICommand command))
+            {
+                command.Execute(arguments, sender, out response);
+                response += $"\nTo view all abilities registered use command: {arguments.Array[0]} {arguments.Array[1]} abilities";
+                return true;
+            }
+
+            response = "Invalid subcommand! Available: registered, abilities";
             return false;
         }
     }

--- a/EXILED/Exiled.CustomRoles/Commands/List/List.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/List/List.cs
@@ -48,7 +48,7 @@ namespace Exiled.CustomRoles.Commands.List
             if (arguments.IsEmpty() && TryGetCommand(Registered.Instance.Command, out ICommand command))
             {
                 command.Execute(arguments, sender, out response);
-                response = string.Join(response, $"\nTo view all abilities registered use command: {arguments.Array[0]} {arguments.Array[1]} abilities");
+                response += $"\nTo view all abilities registered use command: {string.Join(" ", arguments.Array)} abilities";
                 return true;
             }
 

--- a/EXILED/Exiled.CustomRoles/Commands/List/List.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/List/List.cs
@@ -48,7 +48,7 @@ namespace Exiled.CustomRoles.Commands.List
             if (arguments.IsEmpty() && TryGetCommand(Registered.Instance.Command, out ICommand command))
             {
                 command.Execute(arguments, sender, out response);
-                response += $"\nTo view all abilities registered use command: {arguments.Array[0]} {arguments.Array[1]} abilities";
+                response = string.Join(response, $"\nTo view all abilities registered use command: {arguments.Array[0]} {arguments.Array[1]} abilities");
                 return true;
             }
 


### PR DESCRIPTION
## Description
**Describe the changes** 

Using the Custom Item and Custom Roles list commands will execute the registered list if there is no argument.

**What is the current behavior?** (You can also link to an open issue here)
Needless to write registered for a list command and Custom Roles does not say that the ``customrole list abilities`` command exists.

**What is the new behavior?** (if this is a feature change)

Typing the command without arguments will execute the registered command of the list command.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

**Other information**:
Testing result:
### Custom item command
![imagen](https://github.com/user-attachments/assets/9cf0c6da-0b22-4da7-98af-132b1ee19eca)

### Custom roles command
![imagen](https://github.com/user-attachments/assets/2d5468c4-51a8-491e-bfe2-6091a85626a1)

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
