### PR TITLE
``[EXILED::Loader]`` Use nuget

### DIFF
--- a/EXILED/Exiled.Loader/Exiled.Loader.csproj
+++ b/EXILED/Exiled.Loader/Exiled.Loader.csproj
@@ -17,6 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Mono.Posix-4.5" Version="4.5.0" />
         <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)" IncludeAssets="All" PrivateAssets="All" />
         <PackageReference Include="SemanticVersioning" Version="$(SemanticVersioningVersion)" />
     </ItemGroup>


### PR DESCRIPTION
## Description
**Describe the changes** 
Use the [Mono.Posix nuget](https://www.nuget.org/packages/Mono.Posix-4.5) instead of a separate DLL.

**What is the current behavior?** (You can also link to an open issue here)
Using a standalone version of Mono.Posfix may eventually present problems in identifying dependencies, and EXILED uses a version that does not currently exist (4.0.0) at least in NUGET.

**What is the new behavior?** (if this is a feature change)
Honestly, it is not a new function, but simply using the Nuget to better identify where it comes from.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

This change works perfectly on a machine using Linux, all #77 and #78 tests are using this change, but I decided to move my change to a separate PR.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
