### PR TITLE
DroppingScp330 Event Fix.

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
@@ -57,11 +57,13 @@ namespace Exiled.Events.Patches.Events.Scp330
                     // scp330Bag
                     new(OpCodes.Ldloc_1),
 
-                    // scp330Bag.TryRemove(msg.CandyId)
+                    // Load candy bag array to get CandyKindID
                     new(OpCodes.Dup),
+                    new(OpCodes.Ldfld, Field(typeof(Scp330Bag), nameof(Scp330Bag.Candies))),
                     new(OpCodes.Ldarg_1),
+                    // Grab candy ID from network message, and pass it to event args.
                     new(OpCodes.Ldfld, Field(typeof(SelectScp330Message), nameof(SelectScp330Message.CandyID))),
-                    new(OpCodes.Callvirt, Method(typeof(Scp330Bag), nameof(Scp330Bag.TryRemove))),
+                    new(OpCodes.Ldelem_U1),
 
                     // DroppingScp330EventArgs ev = new(Player, Scp330Bag, CandyKindID)
                     new(OpCodes.Newobj, GetDeclaredConstructors(typeof(DroppingScp330EventArgs))[0]),
@@ -83,22 +85,16 @@ namespace Exiled.Events.Patches.Events.Scp330
             int jumpOverIndex = newInstructions.FindLastIndex(
                 instruction => instruction.StoresField(Field(typeof(ItemPickupBase), nameof(ItemPickupBase.PreviousOwner)))) + jumpOverOffset;
 
-            // Remove TryRemove candy logic since we did it earlier from current location
-            newInstructions.RemoveRange(jumpOverIndex, 6);
-
             int candyKindIdIndex = 4;
 
             newInstructions.InsertRange(
                 jumpOverIndex,
                 new[]
                 {
-                    // candyKindID = ev.Candy
+                    // candyKindID = ev.Candy, save locally.
                     new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(DroppingScp330EventArgs), nameof(DroppingScp330EventArgs.Candy))),
-                    new(OpCodes.Stloc, candyKindIdIndex),
-
-                    // candyKindID
-                    new(OpCodes.Ldloc, candyKindIdIndex),
+                    new(OpCodes.Stloc, candyKindIdIndex)
                 });
 
             newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
@@ -61,6 +61,7 @@ namespace Exiled.Events.Patches.Events.Scp330
                     new(OpCodes.Dup),
                     new(OpCodes.Ldfld, Field(typeof(Scp330Bag), nameof(Scp330Bag.Candies))),
                     new(OpCodes.Ldarg_1),
+
                     // Grab candy ID from network message, and pass it to event args.
                     new(OpCodes.Ldfld, Field(typeof(SelectScp330Message), nameof(SelectScp330Message.CandyID))),
                     new(OpCodes.Ldelem_U1),
@@ -94,7 +95,7 @@ namespace Exiled.Events.Patches.Events.Scp330
                     // candyKindID = ev.Candy, save locally.
                     new CodeInstruction(OpCodes.Ldloc, ev.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(DroppingScp330EventArgs), nameof(DroppingScp330EventArgs.Candy))),
-                    new(OpCodes.Stloc, candyKindIdIndex)
+                    new(OpCodes.Stloc, candyKindIdIndex),
                 });
 
             newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);


### PR DESCRIPTION
## Description
**Describe the changes** 
Candy is removed before event could be cancelled. Remove code is now called after. 

**What is the current behavior?** (You can also link to an open issue here)
Candy is removed before event could be cancelled. 

**What is the new behavior?** (if this is a feature change)
N/A

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [?] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [X] I have checked no IL patching errors in the console

### Other
- [X] Still requires more testing
