### PR TITLE
`[EXILED::Events]` Fix downloading NWAPI plugins with `hub install`

### DIFF
--- a/EXILED/Exiled.Events/Commands/Hub/Install.cs
+++ b/EXILED/Exiled.Events/Commands/Hub/Install.cs
@@ -89,9 +89,11 @@ namespace Exiled.Events.Commands.Hub
                 releaseToDownload = foundRelease;
             }
 
-            Log.Info($"Downloading release \"{releaseToDownload.TagName}\". Found {releaseToDownload.Assets.Length} asset(s) to download.");
+            ReleaseAsset[] releaseAssets = releaseToDownload.Assets.Where(x => x.Name.IndexOf("-nwapi", StringComparison.OrdinalIgnoreCase) == -1).ToArray();
 
-            foreach (ReleaseAsset asset in releaseToDownload.Assets)
+            Log.Info($"Downloading release \"{releaseToDownload.TagName}\". Found {releaseAssets.Length} asset(s) to download.");
+
+            foreach (ReleaseAsset asset in releaseAssets)
             {
                 Log.Info($"Downloading asset {asset.Name}. Asset size: {Math.Round(asset.Size / 1000f, 2)} KB.");
                 using HttpResponseMessage assetResponse = client.GetAsync(asset.BrowserDownloadUrl).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/EXILED/Exiled.Events/Commands/Hub/Install.cs
+++ b/EXILED/Exiled.Events/Commands/Hub/Install.cs
@@ -89,7 +89,7 @@ namespace Exiled.Events.Commands.Hub
                 releaseToDownload = foundRelease;
             }
 
-            ReleaseAsset[] releaseAssets = releaseToDownload.Assets.Where(x => x.Name.IndexOf("-nwapi", StringComparison.OrdinalIgnoreCase) == -1).ToArray();
+            ReleaseAsset[] releaseAssets = releaseToDownload.Assets.Where(x => x.Name.IndexOf("nwapi", StringComparison.OrdinalIgnoreCase) == -1).ToArray();
 
             Log.Info($"Downloading release \"{releaseToDownload.TagName}\". Found {releaseAssets.Length} asset(s) to download.");
 


### PR DESCRIPTION
## Description
**Describe the changes** 
This PR fixes the NWAPI plugin installation with the `hub install` command.

**What is the current behavior?** (You can also link to an open issue here)
`hub install` fetches every single asset in the plugin release and downloads it.

**What is the new behavior?** (if this is a feature change)
`hub install` will now filter assets with the `-NWAPI` postfix in the name.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:
-
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
