### PR TITLE
Fix `InteractingScp330EventArgs::Candy`

### DIFF
--- a/EXILED/Exiled.API/Features/Items/Scp330.cs
+++ b/EXILED/Exiled.API/Features/Items/Scp330.cs
@@ -88,6 +88,11 @@ namespace Exiled.API.Features.Items
         public CandyKindID ExposedType { get; set; } = CandyKindID.None;
 
         /// <summary>
+        /// Gets or sets the candy that will be added to the bag. Used for events.
+        /// </summary>
+        internal CandyKindID CandyToAdd { get; set; } = CandyKindID.None;
+
+        /// <summary>
         /// Adds a specific candy to the bag.
         /// </summary>
         /// <param name="type">The <see cref="CandyKindID"/> to add.</param>

--- a/EXILED/Exiled.Events/EventArgs/Scp330/InteractingScp330EventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp330/InteractingScp330EventArgs.cs
@@ -31,12 +31,23 @@ namespace Exiled.Events.EventArgs.Scp330
         public InteractingScp330EventArgs(Player player, int usage)
         {
             Player = player;
-            Scp330 = Scp330Bag.TryGetBag(player.ReferenceHub, out Scp330Bag scp330Bag) ? (Scp330)Item.Get(scp330Bag) : null;
-            Candy = Scp330Candies.GetRandom();
             UsageCount = usage;
             ShouldSever = usage >= 2;
             ShouldPlaySound = true;
             IsAllowed = Player.IsHuman;
+
+            if (Scp330Bag.TryGetBag(player.ReferenceHub, out Scp330Bag scp330Bag))
+            {
+                Scp330 = (Scp330)Item.Get(scp330Bag);
+            }
+            else
+            {
+                Scp330 = (Scp330)Item.Create(ItemType.SCP330, player);
+                Scp330.RemoveAllCandy();
+                player.AddItem(Scp330);
+            }
+
+            Scp330.CandyToAdd = Scp330Candies.GetRandom();
         }
 
         /// <summary>
@@ -47,7 +58,11 @@ namespace Exiled.Events.EventArgs.Scp330
         /// <summary>
         /// Gets or sets a value indicating the type of candy that will be received from this interaction.
         /// </summary>
-        public CandyKindID Candy { get; set; }
+        public CandyKindID Candy
+        {
+            get => Scp330.CandyToAdd;
+            set => Scp330.CandyToAdd = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the player's hands should get severed.
@@ -71,11 +86,9 @@ namespace Exiled.Events.EventArgs.Scp330
         public Player Player { get; }
 
         /// <inheritdoc/>
-        /// <remarks>This value can be null.</remarks>
         public Scp330 Scp330 { get; }
 
         /// <inheritdoc/>
-        /// <remarks>This value can be null.</remarks>
         public Item Item => Scp330;
     }
 }

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/InteractingScp330.cs
@@ -7,14 +7,15 @@
 
 namespace Exiled.Events.Patches.Events.Scp330
 {
+#pragma warning disable SA1402
+#pragma warning disable SA1313
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
     using Exiled.API.Features.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Scp330;
-    using Exiled.Events.Handlers;
     using HarmonyLib;
     using Interactables.Interobjects;
     using InventorySystem.Items.Usables.Scp330;
@@ -26,9 +27,9 @@ namespace Exiled.Events.Patches.Events.Scp330
 
     /// <summary>
     /// Patches the <see cref="Scp330Interobject.ServerInteract(ReferenceHub, byte)" /> method to add the
-    /// <see cref="Scp330.InteractingScp330" /> event.
+    /// <see cref="Handlers.Scp330.InteractingScp330" /> event.
     /// </summary>
-    [EventPatch(typeof(Scp330), nameof(Scp330.InteractingScp330))]
+    [EventPatch(typeof(Handlers.Scp330), nameof(Handlers.Scp330.InteractingScp330))]
     [HarmonyPatch(typeof(Scp330Interobject), nameof(Scp330Interobject.ServerInteract))]
     public static class InteractingScp330
     {
@@ -66,7 +67,7 @@ namespace Exiled.Events.Patches.Events.Scp330
                     new(OpCodes.Stloc, ev.LocalIndex),
 
                     // Scp330.OnInteractingScp330(ev)
-                    new(OpCodes.Call, Method(typeof(Scp330), nameof(Scp330.OnInteractingScp330))),
+                    new(OpCodes.Call, Method(typeof(Handlers.Scp330), nameof(Handlers.Scp330.OnInteractingScp330))),
 
                     // if (!ev.IsAllowed)
                     //    return;
@@ -133,6 +134,22 @@ namespace Exiled.Events.Patches.Events.Scp330
                 yield return newInstructions[z];
 
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    /// Replaces <see cref="Scp330Candies.GetRandom"/> with <see cref="InteractingScp330EventArgs.Candy"/>.
+    /// </summary>
+    [EventPatch(typeof(Handlers.Scp330), nameof(Handlers.Scp330.InteractingScp330))]
+    [HarmonyPatch(typeof(Scp330Bag), nameof(Scp330Bag.TryAddSpecific))]
+    internal static class ReplaceCandy
+    {
+        private static void Prefix(Scp330Bag __instance, ref CandyKindID kind)
+        {
+            Scp330 scp330 = Item.Get<Scp330>(__instance);
+
+            if (scp330.CandyToAdd != CandyKindID.None)
+                kind = scp330.CandyToAdd;
         }
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixing `InteractingScp330EventArgs::Candy`

**What is the current behavior?** (You can also link to an open issue here)
Candy is incorrect
#118

**What is the new behavior?** (if this is a feature change)
Candy is correct

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
