### PR TITLE
spawn fix

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -174,7 +174,7 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Brtrue_S, nothing),
 
                     // nothing
-                    new CodeInstruction(OpCodes.Nop).WithLabels(skip),
+                    new CodeInstruction(OpCodes.Nop).WithLabels(nothing),
 
                     // if (player.ReferenceHub == ReferenceHub.LocalHub)
                     //     goto skip;

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -173,9 +173,6 @@ namespace Exiled.Events.Patches.Events.Player
                     new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
                     new(OpCodes.Brtrue_S, nothing),
 
-                    // nothing
-                    new CodeInstruction(OpCodes.Nop).WithLabels(nothing),
-
                     // if (player.ReferenceHub == ReferenceHub.LocalHub)
                     //     goto skip;
                     new(OpCodes.Ldloc_S, player.LocalIndex),
@@ -183,6 +180,9 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Callvirt, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
                     new(OpCodes.Call, Method(typeof(ReferenceHub), "op_Equality")),
                     new(OpCodes.Brtrue_S, skip),
+
+                    // nothing
+                    new CodeInstruction(OpCodes.Nop).WithLabels(nothing),
 
                     // player
                     new(OpCodes.Ldloc_S, player.LocalIndex),

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -156,6 +156,22 @@ namespace Exiled.Events.Patches.Events.Player
                 newInstructions.Count - 1,
                 new[]
                 {
+                    // if (player == null)
+                    //     goto skip;
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
+                    new(OpCodes.Brtrue_S, skip),
+
+                    // if (player.ReferenceHub == null)
+                    //     goto skip;
+                    new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
+                    new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(API.Features.Player), nameof(API.Features.Player.ReferenceHub))),
+                    new(OpCodes.Brtrue_S, skip),
+
+                    // if (ReferenceHub.LocalHub == null)
+                    //     goto skip;
+                    new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
+                    new(OpCodes.Brtrue_S, skip),
+                    
                     // if (player.ReferenceHub == ReferenceHub.LocalHub)
                     //     goto skip;
                     new(OpCodes.Ldloc_S, player.LocalIndex),

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -45,6 +45,7 @@ namespace Exiled.Events.Patches.Events.Player
             Label continueLabel = generator.DefineLabel();
             Label jmp = generator.DefineLabel();
             Label skip = generator.DefineLabel();
+            Label nothing = generator.DefineLabel();
 
             LocalBuilder changingRoleEventArgs = generator.DeclareLocal(typeof(ChangingRoleEventArgs));
             LocalBuilder player = generator.DeclareLocal(typeof(API.Features.Player));
@@ -157,20 +158,23 @@ namespace Exiled.Events.Patches.Events.Player
                 new[]
                 {
                     // if (player == null)
-                    //     goto skip;
+                    //     goto nothing;
                     new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
-                    new(OpCodes.Brtrue_S, skip),
+                    new(OpCodes.Brtrue_S, nothing),
 
                     // if (player.ReferenceHub == null)
-                    //     goto skip;
+                    //     goto nothing;
                     new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
                     new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(API.Features.Player), nameof(API.Features.Player.ReferenceHub))),
-                    new(OpCodes.Brtrue_S, skip),
+                    new(OpCodes.Brtrue_S, nothing),
 
                     // if (ReferenceHub.LocalHub == null)
-                    //     goto skip;
+                    //     goto nothing;
                     new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
-                    new(OpCodes.Brtrue_S, skip),
+                    new(OpCodes.Brtrue_S, nothing),
+
+                    // nothing
+                    new CodeInstruction(OpCodes.Nop).WithLabels(skip),
 
                     // if (player.ReferenceHub == ReferenceHub.LocalHub)
                     //     goto skip;

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -160,18 +160,18 @@ namespace Exiled.Events.Patches.Events.Player
                     // if (player == null)
                     //     goto nothing;
                     new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
-                    new(OpCodes.Brtrue_S, nothing),
+                    new(OpCodes.Brfalse_S, nothing),
 
                     // if (player.ReferenceHub == null)
                     //     goto nothing;
                     new CodeInstruction(OpCodes.Ldloc_S, player.LocalIndex),
                     new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(API.Features.Player), nameof(API.Features.Player.ReferenceHub))),
-                    new(OpCodes.Brtrue_S, nothing),
+                    new(OpCodes.Brfalse_S, nothing),
 
                     // if (ReferenceHub.LocalHub == null)
                     //     goto nothing;
                     new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
-                    new(OpCodes.Brtrue_S, nothing),
+                    new(OpCodes.Brfalse_S, nothing),
 
                     // if (player.ReferenceHub == ReferenceHub.LocalHub)
                     //     goto skip;

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -171,7 +171,7 @@ namespace Exiled.Events.Patches.Events.Player
                     //     goto skip;
                     new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ReferenceHub), nameof(ReferenceHub.LocalHub))),
                     new(OpCodes.Brtrue_S, skip),
-                    
+
                     // if (player.ReferenceHub == ReferenceHub.LocalHub)
                     //     goto skip;
                     new(OpCodes.Ldloc_S, player.LocalIndex),


### PR DESCRIPTION
## Description
**Describe the changes** 
Added some null judgments before the code of merge  [#148](https://github.com/ExMod-Team/EXILED/pull/148)

**What is the current behavior?** (You can also link to an open issue here)
Throwing an error message when the player enters the server
```
[2024-10-25 16:40:27.376 +08:00] [STDOUT] NullReferenceException: Object reference not set to an instance of an object
[2024-10-25 16:40:27.378 +08:00] [STDOUT]   at (wrapper dynamic-method) PlayerRoles.PlayerRoleManager.PlayerRoles.PlayerRoleManager.InitializeNewRole_Patch0(PlayerRoles.PlayerRoleManager,PlayerRoles.RoleTypeId,PlayerRoles.RoleChangeReason,PlayerRoles.RoleSpawnFlags,Mirror.NetworkReader)
[2024-10-25 16:40:27.378 +08:00] [STDOUT]   at PlayerRoles.PlayerRoleManager.get_CurrentRole () [0x00008] in <0594d213d02e488398c476c559e1ee8e>:0
[2024-10-25 16:40:27.378 +08:00] [STDOUT]   at PlayerRoles.RoleSyncInfoPack.WritePlayers (Mirror.NetworkWriter writer) [0x00026] in <0594d213d02e488398c476c559e1ee8e>:0
[2024-10-25 16:40:27.379 +08:00] [STDOUT]   at PlayerRoles.PlayerRolesNetUtils.WriteRoleSyncInfoPack (Mirror.NetworkWriter writer, PlayerRoles.RoleSyncInfoPack info) [0x00000] in <0594d213d02e488398c476c559e1ee8e>:0
[2024-10-25 16:40:27.379 +08:00] [STDOUT]   at (wrapper delegate-invoke) System.Action`2[Mirror.NetworkWriter,PlayerRoles.RoleSyncInfoPack].invoke_void_T1_T2(Mirror.NetworkWriter,PlayerRoles.RoleSyncInfoPack)
[2024-10-25 16:40:27.379 +08:00] [STDOUT]   at Mirror.NetworkWriter.Write[T] (T value) [0x00023] in <30fac3f6504c4ec7842b66bf8ea075a1>:0
[2024-10-25 16:40:27.379 +08:00] [STDOUT]   at Mirror.NetworkConnection.Send[T] (T message, System.Int32 channelId) [0x00006] in <30fac3f6504c4ec7842b66bf8ea075a1>:0
[2024-10-25 16:40:27.379 +08:00] [STDOUT]   at PlayerRoles.PlayerRolesNetUtils.HandleSpawnedPlayer (ReferenceHub hub) [0x0001b] in <0594d213d02e488398c476c559e1ee8e>:0
[2024-10-25 16:40:27.380 +08:00] [STDOUT]   at (wrapper delegate-invoke) System.Action`1[ReferenceHub].invoke_void_T(ReferenceHub)
[2024-10-25 16:40:27.380 +08:00] [STDOUT]   at (wrapper dynamic-method) ReferenceHub.ReferenceHub.Start_Patch1(ReferenceHub)
```
The server encountered a situation where players can only see a portion of the player models. For example, if there are 12 surviving players, they can only spectate two of them.
**What is the new behavior?** (if this is a feature change)
Players who enter the server now can view all alive players

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
I cannot determine if this fix will cause other errors, so it may be necessary to continue monitoring it or adopt other methods to address this issue.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
