### PR TITLE
Added ability for NPCs to be spawned in a way that they can be seen in the RA

### DIFF
--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -173,7 +173,7 @@ namespace Exiled.API.Features
                 }
                 else
                 {
-                    npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.Unverified;
+                    npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.Host;
                     npc.ReferenceHub.authManager._privUserId = userId == string.Empty ? $"Dummy@localhost" : userId;
                 }
             }

--- a/EXILED/Exiled.API/Features/Npc.cs
+++ b/EXILED/Exiled.API/Features/Npc.cs
@@ -173,7 +173,7 @@ namespace Exiled.API.Features
                 }
                 else
                 {
-                    npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.Host;
+                    npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.Unverified;
                     npc.ReferenceHub.authManager._privUserId = userId == string.Empty ? $"Dummy@localhost" : userId;
                 }
             }
@@ -244,7 +244,7 @@ namespace Exiled.API.Features
                 }
                 else
                 {
-                    npc.ReferenceHub.authManager.InstanceMode = ClientInstanceMode.Unverified;
+                    npc.ReferenceHub.authManager.InstanceMode = userId == PlayerAuthenticationManager.HostId ? ClientInstanceMode.Host : ClientInstanceMode.Unverified;
                     npc.ReferenceHub.authManager._privUserId = userId == string.Empty ? $"Dummy-{npc.Id}@localhost" : userId;
                 }
             }


### PR DESCRIPTION
…mode

## Description
**Describe the changes**
Dummies that declare their userID as PlayerAuthenticationManager.Host will use ClientInstanceMode.Host. This will make it so those dumbies can be seen in the RA making it easier to test. 


**What is the current behavior?** (You can also link to an open issue here)
Current behavior is no matter what setup you use in NPC.Spawn() the dummies won't be seen in the RA. 

**What is the new behavior?** (if this is a feature change)
New Behavior makes it so if you set the userId to PlayerAuthenticationManage.Host then it will spawn a dummy with ClientInstanceMode.Host and you will be able to see them in the RA. 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Shouldn't break anything as you would have to specifically set the userID to PlayerAuthenticationManager.Host.  

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
