### PR TITLE
these are definitely weapons as well

### DIFF
--- a/EXILED/Exiled.API/Features/Items/Item.cs
+++ b/EXILED/Exiled.API/Features/Items/Item.cs
@@ -157,7 +157,7 @@ namespace Exiled.API.Features.Items
         /// <summary>
         /// Gets a value indicating whether or not this item is a weapon.
         /// </summary>
-        public bool IsWeapon => this is Firearm;
+        public bool IsWeapon => this is Firearm || Type is ItemType.Jailbird or ItemType.MicroHID;
 
         /// <summary>
         /// Gets a value indicating whether or not this item emits light.


### PR DESCRIPTION
## Description
**Describe the changes** 


**What is the current behavior?** `Item.IsWeapon` only checks for firearms https://github.com/ExMod-Team/EXILED/blob/9cd0e455bf6454d6df3803ddc7ebf5fc3ed57d56/EXILED/Exiled.API/Features/Items/Item.cs#L160


**What is the new behavior?** Checks for Micro HID and jailbird as well as firearm


**Does this PR introduce a breaking change?** Technically yes, although I can't think of a use case where you wouldn't also want to include other weapons instead of just checking if it's a firearm.


**Other information**: As it technically is breaking, I was considering just making this a method (ideally a different property tho I culdn't think of a good name, hence a method of a similar name)

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
