### PR TITLE
Fixed door unlocking after calling Door.Lock multiple times with the same DoorLockType

### DIFF
--- a/EXILED/Exiled.API/Features/Doors/Door.cs
+++ b/EXILED/Exiled.API/Features/Doors/Door.cs
@@ -500,11 +500,7 @@ namespace Exiled.API.Features.Doors
             else
             {
                 DoorLockType locks = DoorLockType;
-                if (locks.HasFlag(lockType))
-                    locks &= ~lockType;
-                else
-                    locks |= lockType;
-
+                locks |= lockType;
                 Base.NetworkActiveLocks = (ushort)locks;
             }
 


### PR DESCRIPTION
## Description
Fixed door unlocking after calling the Door.Lock multiple times with the same DoorLockType.


**What is the current behavior?** (You can also link to an open issue here)
The Door.Lock method unlocks the door when the same DoorLockType has been used multiple times due to the code in Door.ChangeLock. It doesn't match the method name, so I fixed it.

**What is the new behavior?** (if this is a feature change)
Now, the ChangeLock method only can add new locks.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:
-
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
