### PR TITLE
Add IsScp to RoleExtensions

### DIFF
--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -52,7 +52,7 @@ namespace Exiled.API.Extensions
             Team.FoundationForces or Team.Scientists => Side.Mtf,
             Team.ChaosInsurgency or Team.ClassD => Side.ChaosInsurgency,
             Team.OtherAlive => Side.Tutorial,
-            _ => Side.None,
+            _ => Side.None
         };
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Exiled.API.Extensions
             RoleTypeId.Scp049 or RoleTypeId.Scp939 or RoleTypeId.Scp0492 or RoleTypeId.Scp079 or RoleTypeId.Scp096 or RoleTypeId.Scp106 or RoleTypeId.Scp173 or RoleTypeId.Scp3114 => Team.SCPs,
             RoleTypeId.FacilityGuard or RoleTypeId.NtfCaptain or RoleTypeId.NtfPrivate or RoleTypeId.NtfSergeant or RoleTypeId.NtfSpecialist => Team.FoundationForces,
             RoleTypeId.Tutorial => Team.OtherAlive,
-            _ => Team.Dead,
+            _ => Team.Dead
         };
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Exiled.API.Extensions
             Team.ClassD or Team.ChaosInsurgency => LeadingTeam.ChaosInsurgency,
             Team.FoundationForces or Team.Scientists => LeadingTeam.FacilityForces,
             Team.SCPs => LeadingTeam.Anomalies,
-            _ => LeadingTeam.Draw,
+            _ => LeadingTeam.Draw
         };
 
         /// <summary>
@@ -168,5 +168,12 @@ namespace Exiled.API.Extensions
 
             return info.Ammo.ToDictionary(kvp => kvp.Key.GetAmmoType(), kvp => kvp.Value);
         }
+
+        /// <summary>
+        ///  Checks if the role is an SCP role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is an SCP role.</returns>
+        public static bool IsScp(this RoleTypeId roleType) => roleType.GetTeam() == Team.SCPs;
     }
 }


### PR DESCRIPTION
## Description
Add IsScp to Role Extensions to easily check if the Role is an SCP role, I noticed there was .IsHuman and .IsAlive, but no .IsScp which could be useful to some people


**What is the current behavior?** (You can also link to an open issue here)

You either have to do !RoleTypeId.IsHuman && RoleTypeId.IsAlive or RoleTypeId.Team == Team.SCPs to check if the team is SCPs

**What is the new behavior?** (if this is a feature change)

You can now check with RoleTypeId.IsScp to see if the team is an SCP team or not.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, nobody will need to change anything if they don't want to.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
