### PR TITLE
Add role checks (like IsScp) to Role Extensions / RoleTypeId

### DIFF
--- a/EXILED/EXILED.props
+++ b/EXILED/EXILED.props
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <!-- This is the global version and is used for all projects that don't have a version -->
-    <Version Condition="$(Version) == ''">8.14.1</Version>
+    <Version Condition="$(Version) == ''">8.14.0</Version>
     <!-- Enables public beta warning via the PUBLIC_BETA constant -->
     <PublicBeta>false</PublicBeta>
 

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -124,6 +124,13 @@ namespace Exiled.API.Extensions
         public static bool IsFpcRole(this RoleTypeId roleType) => roleType.GetRoleBase() is IFpcRole;
 
         /// <summary>
+        ///  Checks if the role is an SCP role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is an SCP role.</returns>
+        public static bool IsScp(this RoleTypeId roleType) => roleType.GetTeam() == Team.SCPs;
+
+        /// <summary>
         /// Gets a random spawn point of a <see cref="RoleTypeId"/>.
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/> to get the spawn point from.</param>
@@ -168,12 +175,5 @@ namespace Exiled.API.Extensions
 
             return info.Ammo.ToDictionary(kvp => kvp.Key.GetAmmoType(), kvp => kvp.Value);
         }
-
-        /// <summary>
-        ///  Checks if the role is an SCP role.
-        /// </summary>
-        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
-        /// <returns>A boolean which is true when the role is an SCP role.</returns>
-        public static bool IsScp(this RoleTypeId roleType) => roleType.GetTeam() == Team.SCPs;
     }
 }

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -149,7 +149,7 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
         /// <returns>A boolean which is true when the role is an NTF role.</returns>
-        public static bool IsNtf(this RoleTypeId roleType) => roleType.GetTeam() == Team.FoundationForces;
+        public static bool IsNtf(this RoleTypeId roleType) => roleType.GetTeam() == Team.FoundationForces && roleType != RoleTypeId.FacilityGuard;
 
         /// <summary>
         /// Checks if the role is a Chaos role.

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -135,7 +135,7 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
         /// <returns>A boolean which is true when the role is a human role.</returns>
-        public static bool IsHuman(this RoleTypeId roleType) => roleType.GetTeam() != Team.Dead;
+        public static bool IsHuman(this RoleTypeId roleType) => !roleType.IsDead() && !roleType.IsScp();
 
         /// <summary>
         /// Checks if the role is a dead role.

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -52,7 +52,7 @@ namespace Exiled.API.Extensions
             Team.FoundationForces or Team.Scientists => Side.Mtf,
             Team.ChaosInsurgency or Team.ClassD => Side.ChaosInsurgency,
             Team.OtherAlive => Side.Tutorial,
-            _ => Side.None,
+            _ => Side.None
         };
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Exiled.API.Extensions
             RoleTypeId.Scp049 or RoleTypeId.Scp939 or RoleTypeId.Scp0492 or RoleTypeId.Scp079 or RoleTypeId.Scp096 or RoleTypeId.Scp106 or RoleTypeId.Scp173 or RoleTypeId.Scp3114 => Team.SCPs,
             RoleTypeId.FacilityGuard or RoleTypeId.NtfCaptain or RoleTypeId.NtfPrivate or RoleTypeId.NtfSergeant or RoleTypeId.NtfSpecialist => Team.FoundationForces,
             RoleTypeId.Tutorial => Team.OtherAlive,
-            _ => Team.Dead,
+            _ => Team.Dead
         };
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Exiled.API.Extensions
             Team.ClassD or Team.ChaosInsurgency => LeadingTeam.ChaosInsurgency,
             Team.FoundationForces or Team.Scientists => LeadingTeam.FacilityForces,
             Team.SCPs => LeadingTeam.Anomalies,
-            _ => LeadingTeam.Draw,
+            _ => LeadingTeam.Draw
         };
 
         /// <summary>
@@ -168,5 +168,12 @@ namespace Exiled.API.Extensions
 
             return info.Ammo.ToDictionary(kvp => kvp.Key.GetAmmoType(), kvp => kvp.Value);
         }
+
+        /// <summary>
+        ///  Checks if the role is an SCP role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is an SCP role.</returns>
+        public static bool IsScp(this RoleTypeId roleType) => roleType.GetTeam() == Team.SCPs;
     }
 }

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -131,13 +131,6 @@ namespace Exiled.API.Extensions
         public static bool IsScp(this RoleTypeId roleType) => roleType.GetTeam() == Team.SCPs;
 
         /// <summary>
-        /// Checks if the role is a human role.
-        /// </summary>
-        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
-        /// <returns>A boolean which is true when the role is a human role.</returns>
-        public static bool IsHuman(this RoleTypeId roleType) => !roleType.IsDead() && !roleType.IsScp();
-
-        /// <summary>
         /// Checks if the role is a dead role.
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -148,21 +148,21 @@ namespace Exiled.API.Extensions
         /// Checks if the role is an NTF role.
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
-        /// <returns>A boolean which is true when the role is an NTF role.</returns>
+        /// <returns>A boolean which is true when the role is an NTF role. Does not include Facility Guards.</returns>
         public static bool IsNtf(this RoleTypeId roleType) => roleType.GetTeam() == Team.FoundationForces && roleType != RoleTypeId.FacilityGuard;
 
         /// <summary>
         /// Checks if the role is a Chaos role.
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
-        /// <returns>A boolean which is true when the role is an Chaos role.</returns>
+        /// <returns>A boolean which is true when the role is a Chaos role.</returns>
         public static bool IsChaos(this RoleTypeId roleType) => roleType.GetTeam() == Team.ChaosInsurgency;
 
         /// <summary>
         /// Checks if the role is a military role (Chaos Insurgency or NTF).
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
-        /// <returns>A boolean which is true when the role is a military role.</returns>
+        /// <returns>A boolean which is true when the role is a military role. Does not include Facility Guards.</returns>
         public static bool IsMilitary(this RoleTypeId roleType) => roleType.IsNtf() || roleType.IsChaos();
 
         /// <summary>

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -131,6 +131,48 @@ namespace Exiled.API.Extensions
         public static bool IsScp(this RoleTypeId roleType) => roleType.GetTeam() == Team.SCPs;
 
         /// <summary>
+        /// Checks if the role is a human role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is a human role.</returns>
+        public static bool IsHuman(this RoleTypeId roleType) => roleType.GetTeam() != Team.Dead;
+
+        /// <summary>
+        /// Checks if the role is a dead role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is a dead role.</returns>
+        public static bool IsDead(this RoleTypeId roleType) => roleType.GetTeam() == Team.Dead;
+
+        /// <summary>
+        /// Checks if the role is an NTF role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is an NTF role.</returns>
+        public static bool IsNtf(this RoleTypeId roleType) => roleType.GetTeam() == Team.FoundationForces;
+
+        /// <summary>
+        /// Checks if the role is a Chaos role.
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is an Chaos role.</returns>
+        public static bool IsChaos(this RoleTypeId roleType) => roleType.GetTeam() == Team.ChaosInsurgency;
+
+        /// <summary>
+        /// Checks if the role is a military role (Chaos Insurgency or NTF).
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is a military role.</returns>
+        public static bool IsMilitary(this RoleTypeId roleType) => roleType.IsNtf() || roleType.IsChaos();
+
+        /// <summary>
+        /// Checks if the role is a civilian role (Scientists and Class-D).
+        /// </summary>
+        /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
+        /// <returns>A boolean which is true when the role is a civilian role.</returns>
+        public static bool IsCivilian(this RoleTypeId roleType) => roleType == RoleTypeId.ClassD || roleType == RoleTypeId.Scientist;
+
+        /// <summary>
         /// Gets a random spawn point of a <see cref="RoleTypeId"/>.
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/> to get the spawn point from.</param>

--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -52,7 +52,7 @@ namespace Exiled.API.Extensions
             Team.FoundationForces or Team.Scientists => Side.Mtf,
             Team.ChaosInsurgency or Team.ClassD => Side.ChaosInsurgency,
             Team.OtherAlive => Side.Tutorial,
-            _ => Side.None
+            _ => Side.None,
         };
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Exiled.API.Extensions
             RoleTypeId.Scp049 or RoleTypeId.Scp939 or RoleTypeId.Scp0492 or RoleTypeId.Scp079 or RoleTypeId.Scp096 or RoleTypeId.Scp106 or RoleTypeId.Scp173 or RoleTypeId.Scp3114 => Team.SCPs,
             RoleTypeId.FacilityGuard or RoleTypeId.NtfCaptain or RoleTypeId.NtfPrivate or RoleTypeId.NtfSergeant or RoleTypeId.NtfSpecialist => Team.FoundationForces,
             RoleTypeId.Tutorial => Team.OtherAlive,
-            _ => Team.Dead
+            _ => Team.Dead,
         };
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Exiled.API.Extensions
             Team.ClassD or Team.ChaosInsurgency => LeadingTeam.ChaosInsurgency,
             Team.FoundationForces or Team.Scientists => LeadingTeam.FacilityForces,
             Team.SCPs => LeadingTeam.Anomalies,
-            _ => LeadingTeam.Draw
+            _ => LeadingTeam.Draw,
         };
 
         /// <summary>

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -704,7 +704,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any human rank.
         /// </summary>
-        public bool IsHuman => RoleExtensions.IsHuman(Role?.Type ?? RoleTypeId.None);
+        public bool IsHuman => Role is not null && RoleExtensions.IsHuman(Role.Type);
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is equal to <see cref="RoleTypeId.Tutorial"/>.

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -687,13 +687,13 @@ namespace Exiled.API.Features
         /// Equivalent to checking the player's <see cref="Team"/>.
         /// </summary>
         // TODO: Change logic for FacilityGuard in next major update
-        public bool IsNTF => Role?.Type.IsNtf() ?? false;
+        public bool IsNTF => Role?.Team is Team.FoundationForces;
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any Chaos rank.
         /// Equivalent to checking the player's <see cref="Team"/>.
         /// </summary>
-        public bool IsCHI => Role?.Type.IsChaos() ?? false;
+        public bool IsCHI => Role?.Team is Team.ChaosInsurgency;
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any SCP.
@@ -704,7 +704,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any human rank.
         /// </summary>
-        public bool IsHuman => Role is not null && RoleExtensions.IsHuman(Role.Type);
+        public bool IsHuman => Role is not null && Role.Is(out HumanRole _);
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is equal to <see cref="RoleTypeId.Tutorial"/>.

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -687,24 +687,24 @@ namespace Exiled.API.Features
         /// Equivalent to checking the player's <see cref="Team"/>.
         /// </summary>
         // TODO: Change logic for FacilityGuard in next major update
-        public bool IsNTF => Role?.Team is Team.FoundationForces;
+        public bool IsNTF => Role?.Type.IsNtf() ?? false;
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any Chaos rank.
         /// Equivalent to checking the player's <see cref="Team"/>.
         /// </summary>
-        public bool IsCHI => Role?.Team is Team.ChaosInsurgency;
+        public bool IsCHI => Role?.Type.IsChaos() ?? false;
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any SCP.
         /// Equivalent to checking the player's <see cref="Team"/>.
         /// </summary>
-        public bool IsScp => Role?.Team is Team.SCPs;
+        public bool IsScp => Role?.Type.IsScp() ?? false;
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is any human rank.
         /// </summary>
-        public bool IsHuman => Role is not null && Role.Is(out HumanRole _);
+        public bool IsHuman => RoleExtensions.IsHuman(Role?.Type ?? RoleTypeId.None);
 
         /// <summary>
         /// Gets a value indicating whether or not the player's <see cref="RoleTypeId"/> is equal to <see cref="RoleTypeId.Tutorial"/>.


### PR DESCRIPTION
## Description
Add IsScp to Role Extensions to easily check if the Role is an SCP role, I noticed there was .IsHuman and .IsAlive, but no .IsScp which could be useful to some people


**What is the current behavior?** (You can also link to an open issue here)

You either have to do !RoleTypeId.IsHuman && RoleTypeId.IsAlive or RoleTypeId.Team == Team.SCPs to check if the team is SCPs

**What is the new behavior?** (if this is a feature change)

You can now check with RoleTypeId.IsScp to see if the team is an SCP team or not.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, nobody will need to change anything if they don't want to.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
