### PR TITLE
Updated CustomItems & CustomRoles give commands to use default RAUtils.ProcessPlayerIdOrNamesList

### DIFF
--- a/EXILED/EXILED.props
+++ b/EXILED/EXILED.props
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <!-- This is the global version and is used for all projects that don't have a version -->
-    <Version Condition="$(Version) == ''">8.14.0</Version>
+    <Version Condition="$(Version) == ''">8.14.1</Version>
     <!-- Enables public beta warning via the PUBLIC_BETA constant -->
     <PublicBeta>false</PublicBeta>
 

--- a/EXILED/EXILED.props
+++ b/EXILED/EXILED.props
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <!-- This is the global version and is used for all projects that don't have a version -->
-    <Version Condition="$(Version) == ''">8.14.1</Version>
+    <Version Condition="$(Version) == ''">8.14.0</Version>
     <!-- Enables public beta warning via the PUBLIC_BETA constant -->
     <PublicBeta>false</PublicBeta>
 

--- a/EXILED/Exiled.CustomItems/Commands/Give.cs
+++ b/EXILED/Exiled.CustomItems/Commands/Give.cs
@@ -104,7 +104,7 @@ namespace Exiled.CustomItems.Commands
 
             IEnumerable<Player> list = Player.GetProcessedData(arguments, 1);
 
-            if (list == null)
+            if (list.IsEmpty())
             {
                 response = "Cannot find player! Try using the player ID!";
                 return false;

--- a/EXILED/Exiled.CustomItems/Commands/Give.cs
+++ b/EXILED/Exiled.CustomItems/Commands/Give.cs
@@ -84,6 +84,7 @@ namespace Exiled.CustomItems.Commands
                 response = "Failed to provide a valid player, please follow the syntax.";
                 return false;
             }
+            
             string identifier = string.Join(" ", arguments.Skip(1));
 
             switch (identifier)
@@ -99,6 +100,7 @@ namespace Exiled.CustomItems.Commands
                 default:
                     break;
             }
+            
             string[] newargs;
             List<ReferenceHub> list = RAUtils.ProcessPlayerIdOrNamesList(arguments, 1, out newargs);
             if (list == null)
@@ -106,6 +108,7 @@ namespace Exiled.CustomItems.Commands
                 response = "Cannot find player! Try using the player ID!";
                 return false;
             }
+            
             foreach (ReferenceHub hub in list)
             {
                 Player player = Player.Get(hub);
@@ -116,15 +119,18 @@ namespace Exiled.CustomItems.Commands
 
                 item?.Give(player);
             }
+            
             if (list.Count == 1)
             {
                 Player player = Player.Get(list[0]);
                 response = $"{item?.Name} given to {player.Nickname} ({player.UserId})";
             }
+
             else
             {
                 response = $"{item?.Name} given to {list.Count} players!";
             }
+            
             return true;
 
         }

--- a/EXILED/Exiled.CustomItems/Commands/Give.cs
+++ b/EXILED/Exiled.CustomItems/Commands/Give.cs
@@ -18,6 +18,7 @@ namespace Exiled.CustomItems.Commands
     using Exiled.Permissions.Extensions;
 
     using RemoteAdmin;
+    using UnityStandardAssets.Effects;
     using Utils;
 
     /// <summary>
@@ -101,35 +102,23 @@ namespace Exiled.CustomItems.Commands
                     break;
             }
 
-            string[] newargs;
-            List<ReferenceHub> list = RAUtils.ProcessPlayerIdOrNamesList(arguments, 1, out newargs);
+            IEnumerable<Player> list = Player.GetProcessedData(arguments, 1);
+
             if (list == null)
             {
                 response = "Cannot find player! Try using the player ID!";
                 return false;
             }
 
-            foreach (ReferenceHub hub in list)
+            foreach (Player player in list)
             {
-                Player player = Player.Get(hub);
-                if (!CheckEligible(player))
+                if (CheckEligible(player))
                 {
-                    list.Remove(hub);
+                    item?.Give(player);
                 }
-
-                item?.Give(player);
             }
 
-            if (list.Count == 1)
-            {
-                Player player = Player.Get(list[0]);
-                response = $"{item?.Name} given to {player.Nickname} ({player.UserId})";
-            }
-            else
-            {
-                response = $"{item?.Name} given to {list.Count} players!";
-            }
-
+            response = $"{item?.Name} given to {list.Count()} players!";
             return true;
         }
 

--- a/EXILED/Exiled.CustomItems/Commands/Give.cs
+++ b/EXILED/Exiled.CustomItems/Commands/Give.cs
@@ -84,7 +84,7 @@ namespace Exiled.CustomItems.Commands
                 response = "Failed to provide a valid player, please follow the syntax.";
                 return false;
             }
-            
+
             string identifier = string.Join(" ", arguments.Skip(1));
 
             switch (identifier)
@@ -100,7 +100,7 @@ namespace Exiled.CustomItems.Commands
                 default:
                     break;
             }
-            
+
             string[] newargs;
             List<ReferenceHub> list = RAUtils.ProcessPlayerIdOrNamesList(arguments, 1, out newargs);
             if (list == null)
@@ -108,7 +108,7 @@ namespace Exiled.CustomItems.Commands
                 response = "Cannot find player! Try using the player ID!";
                 return false;
             }
-            
+
             foreach (ReferenceHub hub in list)
             {
                 Player player = Player.Get(hub);
@@ -119,20 +119,18 @@ namespace Exiled.CustomItems.Commands
 
                 item?.Give(player);
             }
-            
+
             if (list.Count == 1)
             {
                 Player player = Player.Get(list[0]);
                 response = $"{item?.Name} given to {player.Nickname} ({player.UserId})";
             }
-
             else
             {
                 response = $"{item?.Name} given to {list.Count} players!";
             }
-            
-            return true;
 
+            return true;
         }
 
         /// <summary>

--- a/EXILED/Exiled.CustomRoles/Commands/Give.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/Give.cs
@@ -100,30 +100,19 @@ namespace Exiled.CustomRoles.Commands
                         break;
                 }
 
-                string[] newargs;
-                List<ReferenceHub> list = RAUtils.ProcessPlayerIdOrNamesList(arguments, 1, out newargs);
+                IEnumerable<Player> list = Player.GetProcessedData(arguments, 1);
                 if (list == null)
                 {
                     response = "Cannot find player! Try using the player ID!";
                     return false;
                 }
 
-                foreach (ReferenceHub hub in list)
+                foreach (Player player in list)
                 {
-                    Player player = Player.Get(hub);
                     role.AddRole(player);
                 }
 
-                if (list.Count == 1)
-                {
-                    Player player = Player.Get(list[0]);
-                    role.AddRole(player);
-                    response = $"Customrole {role.Name} given to {player.Nickname} ({player.UserId})";
-                }
-                else
-                {
-                    response = $"Customrole {role.Name} given to {list.Count} players!";
-                }
+                response = $"Customrole {role.Name} given to {list.Count()} players!";
 
                 return true;
             }

--- a/EXILED/Exiled.CustomRoles/Commands/Give.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/Give.cs
@@ -101,7 +101,7 @@ namespace Exiled.CustomRoles.Commands
                 }
 
                 IEnumerable<Player> list = Player.GetProcessedData(arguments, 1);
-                if (list == null)
+                if (list.IsEmpty())
                 {
                     response = "Cannot find player! Try using the player ID!";
                     return false;

--- a/EXILED/Exiled.CustomRoles/Commands/Give.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/Give.cs
@@ -19,6 +19,8 @@ namespace Exiled.CustomRoles.Commands
     using Exiled.Permissions.Extensions;
 
     using RemoteAdmin;
+    using static HarmonyLib.Code;
+    using Utils;
 
     /// <summary>
     /// The command to give a role to player(s).
@@ -96,16 +98,31 @@ namespace Exiled.CustomRoles.Commands
                         ListPool<Player>.Pool.Return(players);
                         return true;
                     default:
-                        if (Player.Get(identifier) is not Player ply)
-                        {
-                            response = $"Unable to find a player: {identifier}";
-                            return false;
-                        }
-
-                        role.AddRole(ply);
-                        response = $"{role.Name} given to {ply.Nickname}.";
-                        return true;
+                        break;
                 }
+                string[] newargs;
+                List<ReferenceHub> list = RAUtils.ProcessPlayerIdOrNamesList(arguments, 1, out newargs);
+                if (list == null)
+                {
+                    response = "Cannot find player! Try using the player ID!";
+                    return false;
+                }
+                foreach (ReferenceHub hub in list)
+                {
+                    Player player = Player.Get(hub);
+                    role.AddRole(player);
+                }
+                if (list.Count == 1)
+                {
+                    Player player = Player.Get(list[0]);
+                    role.AddRole(player);
+                    response = $"Customrole {role.Name} given to {player.Nickname} ({player.UserId})";
+                }
+                else
+                {
+                    response = $"Customrole {role.Name} given to {list.Count} players!";
+                }
+                return true;
             }
             catch (Exception e)
             {

--- a/EXILED/Exiled.CustomRoles/Commands/Give.cs
+++ b/EXILED/Exiled.CustomRoles/Commands/Give.cs
@@ -19,7 +19,6 @@ namespace Exiled.CustomRoles.Commands
     using Exiled.Permissions.Extensions;
 
     using RemoteAdmin;
-    using static HarmonyLib.Code;
     using Utils;
 
     /// <summary>
@@ -100,6 +99,7 @@ namespace Exiled.CustomRoles.Commands
                     default:
                         break;
                 }
+
                 string[] newargs;
                 List<ReferenceHub> list = RAUtils.ProcessPlayerIdOrNamesList(arguments, 1, out newargs);
                 if (list == null)
@@ -107,11 +107,13 @@ namespace Exiled.CustomRoles.Commands
                     response = "Cannot find player! Try using the player ID!";
                     return false;
                 }
+
                 foreach (ReferenceHub hub in list)
                 {
                     Player player = Player.Get(hub);
                     role.AddRole(player);
                 }
+
                 if (list.Count == 1)
                 {
                     Player player = Player.Get(list[0]);
@@ -122,6 +124,7 @@ namespace Exiled.CustomRoles.Commands
                 {
                     response = $"Customrole {role.Name} given to {list.Count} players!";
                 }
+
                 return true;
             }
             catch (Exception e)


### PR DESCRIPTION
## Description
**Describe the changes** 


**What is the current behavior?** (You can also link to an open issue here)
Commands currently evaluate only `*`, `all`, or `Player.Id`

**What is the new behavior?** (if this is a feature change)
Commands now evaluate players based on `RAUtils.ProcessPlayerIdOrNamesList` (eg `@player.17.15`) as well as `*`, `all`, or `Player.Id`.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [X] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
