### PR TITLE
Update RoleExtensions.IsMilitary to reflect how the wiki categorizes guards

### DIFF
--- a/EXILED/Exiled.API/Extensions/RoleExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/RoleExtensions.cs
@@ -156,7 +156,7 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="roleType">The <see cref="RoleTypeId"/>.</param>
         /// <returns>A boolean which is true when the role is a military role. Does not include Facility Guards.</returns>
-        public static bool IsMilitary(this RoleTypeId roleType) => roleType.IsNtf() || roleType.IsChaos();
+        public static bool IsMilitary(this RoleTypeId roleType) => roleType.IsNtf() || roleType.IsChaos() || roleType == RoleTypeId.FacilityGuard;
 
         /// <summary>
         /// Checks if the role is a civilian role (Scientists and Class-D).


### PR DESCRIPTION
## Description
**Describe the changes** 
`RoleExtensions.IsMilitary()` returns true for guards, this is because the official wiki classifies them as militant classes 
![image](https://github.com/user-attachments/assets/c7ca8909-0d3f-4308-b34b-846b77197f14)
![image](https://github.com/user-attachments/assets/b123e89f-7aa1-4fe1-ac5e-744849c0f495)
https://en.scpslgame.com/index.php?title=Humans
https://en.scpslgame.com/index.php?title=Facility_Guard

**What is the current behavior?** (You can also link to an open issue here)
`RoleExtensions.IsMilitary()` returns false for guards

**What is the new behavior?** (if this is a feature change)
`RoleExtensions.IsMilitary()` returns true for guards as well

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
