### PR TITLE
Quick fix for room types not getting identified

### DIFF
--- a/EXILED/Exiled.API/Enums/DoorType.cs
+++ b/EXILED/Exiled.API/Enums/DoorType.cs
@@ -156,7 +156,7 @@ namespace Exiled.API.Enums
         /// Represents any heavy containment styled door.
         /// </summary>
         HeavyContainmentDoor,
-        
+
         /// <summary>
         /// Represents any heavy containment styled door.
         /// </summary>

--- a/EXILED/Exiled.API/Enums/DoorType.cs
+++ b/EXILED/Exiled.API/Enums/DoorType.cs
@@ -158,7 +158,7 @@ namespace Exiled.API.Enums
         HeavyContainmentDoor,
 
         /// <summary>
-        /// Represents any heavy containment styled door.
+        /// Represents explosion proof containment door.
         /// </summary>
         HeavyBulkDoor,
 

--- a/EXILED/Exiled.API/Extensions/StringExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/StringExtensions.cs
@@ -119,12 +119,12 @@ namespace Exiled.API.Extensions
         /// <returns>Name without brackets.</returns>
         public static string RemoveBracketsOnEndOfName(this string name)
         {
-            // int bracketStart = name.IndexOf('(') - 1;
-            //
-            // if (bracketStart > 0)
-            //     name = name.Remove(bracketStart, name.Length - bracketStart);
+            int bracketStart = name.IndexOf('(');
 
-            return name.Replace("(Clone)", "");
+            if (bracketStart > 0)
+                name = name.Remove(bracketStart, name.Length - bracketStart);
+
+            return name;
         }
 
         /// <summary>

--- a/EXILED/Exiled.API/Extensions/StringExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/StringExtensions.cs
@@ -119,12 +119,12 @@ namespace Exiled.API.Extensions
         /// <returns>Name without brackets.</returns>
         public static string RemoveBracketsOnEndOfName(this string name)
         {
-            int bracketStart = name.IndexOf('(') - 1;
+            // int bracketStart = name.IndexOf('(') - 1;
+            //
+            // if (bracketStart > 0)
+            //     name = name.Remove(bracketStart, name.Length - bracketStart);
 
-            if (bracketStart > 0)
-                name = name.Remove(bracketStart, name.Length - bracketStart);
-
-            return name;
+            return name.Replace("(Clone)", "");
         }
 
         /// <summary>

--- a/EXILED/Exiled.API/Features/Doors/Door.cs
+++ b/EXILED/Exiled.API/Features/Doors/Door.cs
@@ -589,17 +589,18 @@ namespace Exiled.API.Features.Doors
             if (Nametag is null)
             {
                 string doorName = GameObject.name.GetBefore(' ');
+
                 // Log.Error($"What is door type {doorName} versus {GameObject.name}");
-                //Temp, Exiled should not be using a space identifier but I am on vacation
+                // Temp, Exiled should not be using a space identifier but I am on vacation
                 if (doorName.Equals("HCZ"))
                 {
                     doorName = GameObject.name.GetBefore('(');
                 }
+
                 // Log.Error($"What is door type {doorName} versus {GameObject.name}");
                 // Correct behavior would be to just cut (clone) off the end
                 // If you want, have two item definitions - 1 - HCZ doors group
                 // 2 - HCZ specific door (HCZ - Breakable, Blastdoor, etc)
-
                 return doorName switch
                 {
                     "LCZ" => Room?.Type switch

--- a/EXILED/Exiled.API/Features/Room.cs
+++ b/EXILED/Exiled.API/Features/Room.cs
@@ -501,7 +501,7 @@ namespace Exiled.API.Features
             Type = FindType(gameObject);
 #if DEBUG
             if (Type is RoomType.Unknown)
-                Log.Error($"[ROOMTYPE UNKNOWN] {this} {gameObject.name} versus {gameObject?.name.RemoveBracketsOnEndOfName()}");
+                Log.Error($"[ROOMTYPE UNKNOWN] {this} {gameObject.name} versus {gameObject.name.RemoveBracketsOnEndOfName()}");
 #endif
 
             RoomLightControllersValue.AddRange(gameObject.GetComponentsInChildren<RoomLightController>());

--- a/EXILED/Exiled.API/Features/Room.cs
+++ b/EXILED/Exiled.API/Features/Room.cs
@@ -495,13 +495,13 @@ namespace Exiled.API.Features
 
             Zone = FindZone(gameObject);
 #if DEBUG
-            if (Type is RoomType.Unknown)
-                Log.Error($"[ZONETYPE UNKNOWN] {this}");
+            if (Zone is ZoneType.Other)
+                Log.Error($"[ZONETYPE UNKNOWN] {this} {gameObject.transform.parent?.name} versus {gameObject.transform.parent?.name.RemoveBracketsOnEndOfName()}");
 #endif
             Type = FindType(gameObject);
 #if DEBUG
             if (Type is RoomType.Unknown)
-                Log.Error($"[ROOMTYPE UNKNOWN] {this}");
+                Log.Error($"[ROOMTYPE UNKNOWN] {this} {gameObject.name} versus {gameObject?.name.RemoveBracketsOnEndOfName()}");
 #endif
 
             RoomLightControllersValue.AddRange(gameObject.GetComponentsInChildren<RoomLightController>());


### PR DESCRIPTION
Original answer: [ROOMTYPE UNKNOWN] Unknown (LightContainment) [] ** |False| LCZ_TCross(Clone) versus LCZ_TCros
New Answer: [ROOMTYPE UNKNOWN] Unknown (LightContainment) [] ** |False| LCZ_TCross(Clone) versus LCZ_TCross
(see TCros vs TCross)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [X] I have checked no IL patching errors in the console

### Other
- [X] Still requires more testing
