### PR TITLE
Fix `Exiled.Events.EventArgs.Scp079.ElevatorTeleportingEventArgs` & Lift.List empty

### DIFF
--- a/EXILED/Exiled.API/Features/Lift.cs
+++ b/EXILED/Exiled.API/Features/Lift.cs
@@ -33,7 +33,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// A <see cref="Dictionary{TKey,TValue}"/> containing all known <see cref="ElevatorChamber"/>s and their corresponding <see cref="Lift"/>.
         /// </summary>
-        internal static readonly Dictionary<ElevatorChamber, Lift> ElevatorChamberToLift = new(8, new ComponentsEqualityComparer());
+        internal static readonly Dictionary<ElevatorChamber, Lift> ElevatorChamberToLift = new(9, new ComponentsEqualityComparer());
 
         /// <summary>
         /// Internal list that contains all ElevatorDoor for current group.

--- a/EXILED/Exiled.Events/EventArgs/Scp079/ElevatorTeleportingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp079/ElevatorTeleportingEventArgs.cs
@@ -29,18 +29,18 @@ namespace Exiled.Events.EventArgs.Scp079
         /// <param name="room">
         /// <inheritdoc cref="Room" />
         /// </param>
-        /// <param name="elevatorDoor">
+        /// <param name="elevatorChamber">
         /// <inheritdoc cref="Lift" />
         /// </param>
         /// <param name="auxiliaryPowerCost">
         /// <inheritdoc cref="AuxiliaryPowerCost" />
         /// </param>
-        public ElevatorTeleportingEventArgs(Player player, RoomIdentifier room, ElevatorDoor elevatorDoor, float auxiliaryPowerCost)
+        public ElevatorTeleportingEventArgs(Player player, RoomIdentifier room, ElevatorChamber elevatorChamber, float auxiliaryPowerCost)
         {
             Player = player;
             Scp079 = player.Role.As<Scp079Role>();
             Room = Room.Get(room);
-            Lift = Lift.Get(elevatorDoor.Chamber);
+            Lift = Lift.Get(elevatorChamber);
             AuxiliaryPowerCost = auxiliaryPowerCost;
             IsAllowed = auxiliaryPowerCost <= Scp079.Energy;
         }

--- a/EXILED/Exiled.Events/Patches/Generic/LiftList.cs
+++ b/EXILED/Exiled.Events/Patches/Generic/LiftList.cs
@@ -7,25 +7,24 @@
 
 namespace Exiled.Events.Patches.Generic
 {
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
     using API.Features;
 
     using HarmonyLib;
     using Interactables.Interobjects;
 
     /// <summary>
-    /// Patches <see cref="ElevatorManager.SpawnAllChambers"/>.
+    /// Patches to control <see cref="Lift.List"/>.
     /// </summary>
-    [HarmonyPatch(typeof(ElevatorManager), nameof(ElevatorManager.SpawnAllChambers))]
+    [HarmonyPatch]
     internal class LiftList
     {
-        private static void Postfix()
-        {
-            Lift.ElevatorChamberToLift.Clear();
+        [HarmonyPatch(typeof(ElevatorChamber), nameof(ElevatorChamber.Start))]
+        [HarmonyPostfix]
+        private static void Adding(ElevatorChamber __instance) => _ = new Lift(__instance);
 
-            foreach (ElevatorChamber lift in ElevatorChamber.AllChambers)
-            {
-                _ = new Lift(lift);
-            }
-        }
+        [HarmonyPatch(typeof(ElevatorChamber), nameof(ElevatorChamber.OnDestroy))]
+        [HarmonyPostfix]
+        private static void Removing(ElevatorChamber __instance) => Lift.ElevatorChamberToLift.Remove(__instance);
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
Rework the patch of ElevatorTeleporting event.
Rework the patch that handles Lift.List.

**What is the current behavior?** (You can also link to an open issue here)
Activating an elevator as SCP-079 make the player crash.

**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
