### PR TITLE
Removing typeLookupTable

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -158,11 +158,11 @@ namespace Exiled.CustomItems.API.Features
         }
 
         /// <summary>
-        /// Gets a <see cref="CustomItem"/> with a specific type.
+        /// Retrieves a collection of <see cref="CustomItem"/> instances that match a specified type.
         /// </summary>
         /// <param name="t">The <see cref="System.Type"/> type.</param>
-        /// <returns>The <see cref="CustomItem"/> matching the search, <see langwod="null"/> if not registered.</returns>
-        public static CustomItem? Get(Type t) => Registered.FirstOrDefault(i => i.GetType() == t);
+        /// <returns>An <see cref="IEnumerable{CustomItem}"/> containing all registered <see cref="CustomItem"/> of the specified type.</returns>
+        public static IEnumerable<CustomItem> Get(Type t) => Registered.Where(i => i.GetType() == t);
 
         /// <summary>
         /// Tries to get a <see cref="CustomItem"/> with a specific ID.
@@ -195,16 +195,16 @@ namespace Exiled.CustomItems.API.Features
         }
 
         /// <summary>
-        /// Tries to get a <see cref="CustomItem"/> with a specific type.
+        /// Attempts to retrieve a collection of <see cref="CustomItem"/> instances of a specified type.
         /// </summary>
         /// <param name="t">The <see cref="System.Type"/> of the item to look for.</param>
-        /// <param name="customItem">The found <see cref="CustomItem"/>, <see langword="null"/> if not registered.</param>
-        /// <returns>Returns a value indicating whether the <see cref="CustomItem"/> was found.</returns>
-        public static bool TryGet(Type t, out CustomItem? customItem)
+        /// <param name="customItems">An output parameter that will contain the found <see cref="CustomItem"/> instances, or an empty collection if none are registered.</param>
+        /// <returns>A boolean value indicating whether any <see cref="CustomItem"/> instances of the specified type were found.</returns>
+        public static bool TryGet(Type t, out IEnumerable<CustomItem> customItems)
         {
-            customItem = Get(t);
+            customItems = Get(t);
 
-            return customItem is not null;
+            return customItems.Any();
         }
 
         /// <summary>
@@ -346,12 +346,16 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="t">The <see cref="System.Type"/> of the item to give.</param>
         /// <param name="displayMessage">Indicates a value whether <see cref="ShowPickedUpMessage"/> will be called when the player receives the <see cref="CustomItem"/> or not.</param>
         /// <returns>Returns a value indicating if the player was given the <see cref="CustomItem"/> or not.</returns>
+        /// <remarks>
+        /// This method will give the first registered <see cref="CustomItem"/> of the specified type to the player.
+        /// If no items of the specified type are found, the method will return false.
+        /// </remarks>
         public static bool TryGive(Player player, Type t, bool displayMessage = true)
         {
-            if (!TryGet(t, out CustomItem? item))
+            if (!TryGet(t, out IEnumerable<CustomItem> items))
                 return false;
 
-            item?.Give(player, displayMessage);
+            items.First().Give(player, displayMessage);
 
             return true;
         }

--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -53,7 +53,6 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     public abstract class CustomItem
     {
-        private static Dictionary<Type, CustomItem?> typeLookupTable = new();
         private static Dictionary<string, CustomItem?> stringLookupTable = new();
         private static Dictionary<uint, CustomItem?> idLookupTable = new();
 
@@ -163,12 +162,7 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         /// <param name="t">The <see cref="System.Type"/> type.</param>
         /// <returns>The <see cref="CustomItem"/> matching the search, <see langwod="null"/> if not registered.</returns>
-        public static CustomItem? Get(Type t)
-        {
-            if (!typeLookupTable.ContainsKey(t))
-                typeLookupTable.Add(t, Registered.FirstOrDefault(i => i.GetType() == t));
-            return typeLookupTable[t];
-        }
+        public static CustomItem? Get(Type t) => Registered.FirstOrDefault(i => i.GetType() == t);
 
         /// <summary>
         /// Tries to get a <see cref="CustomItem"/> with a specific ID.
@@ -770,7 +764,6 @@ namespace Exiled.CustomItems.API.Features
         /// </summary>
         public virtual void Init()
         {
-            typeLookupTable.Add(GetType(), this);
             stringLookupTable.Add(Name, this);
             idLookupTable.Add(Id, this);
 
@@ -784,7 +777,6 @@ namespace Exiled.CustomItems.API.Features
         {
             UnsubscribeEvents();
 
-            typeLookupTable.Remove(GetType());
             stringLookupTable.Remove(Name);
             idLookupTable.Remove(Id);
         }

--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -340,27 +340,6 @@ namespace Exiled.CustomItems.API.Features
         }
 
         /// <summary>
-        /// Gives to a specific <see cref="Player"/> a specic <see cref="CustomItem"/>.
-        /// </summary>
-        /// <param name="player">The <see cref="Player"/> to give the item to.</param>
-        /// <param name="t">The <see cref="System.Type"/> of the item to give.</param>
-        /// <param name="displayMessage">Indicates a value whether <see cref="ShowPickedUpMessage"/> will be called when the player receives the <see cref="CustomItem"/> or not.</param>
-        /// <returns>Returns a value indicating if the player was given the <see cref="CustomItem"/> or not.</returns>
-        /// <remarks>
-        /// This method will give the first registered <see cref="CustomItem"/> of the specified type to the player.
-        /// If no items of the specified type are found, the method will return false.
-        /// </remarks>
-        public static bool TryGive(Player player, Type t, bool displayMessage = true)
-        {
-            if (!TryGet(t, out IEnumerable<CustomItem> items))
-                return false;
-
-            items.First().Give(player, displayMessage);
-
-            return true;
-        }
-
-        /// <summary>
         /// Registers all the <see cref="CustomItem"/>'s present in the current assembly.
         /// </summary>
         /// <param name="skipReflection">Whether reflection is skipped (more efficient if you are not using your custom item classes as config objects).</param>


### PR DESCRIPTION
## Description
**Describe the changes** 
Removing typeLookupTable in Customitems
When attempting to create multiple `CustomItem` instances of the same type, an exception was thrown. The type is not a unique property for creating a dictionary.

**What is the current behavior?** (You can also link to an open issue here)
typeLookupTable is exists

**What is the new behavior?** (if this is a feature change)
no more typeLookupTable 😈

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
