### PR TITLE
Fix Player comparison

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -3724,6 +3724,37 @@ namespace Exiled.API.Features
         /// <param name="projectileType">The projectile that will create the effect.</param>
         public void ExplodeEffect(ProjectileType projectileType) => Map.ExplodeEffect(Position, projectileType);
 
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            Player player = obj as Player;
+            return (object)player != null && ReferenceHub == player.ReferenceHub;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return ReferenceHub.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns whether the two players are the same.
+        /// </summary>
+        /// <param name="player1">The first player instance.</param>
+        /// <param name="player2">The second player instance.</param>
+        /// <returns><see langword="true"/> if the values are equal.</returns>
+#pragma warning disable SA1201
+        public static bool operator ==(Player player1, Player player2) => player1?.Equals(player2) ?? player2 is null;
+
+        /// <summary>
+        /// Returns whether the two players are different.
+        /// </summary>
+        /// <param name="player1">The first player instance.</param>
+        /// <param name="player2">The second player instance.</param>
+        /// <returns><see langword="true"/> if the values are not equal.</returns>
+        public static bool operator !=(Player player1, Player player2) => !(player1 == player2);
+#pragma warning restore SA1201
+
         /// <summary>
         /// Converts the player in a human-readable format.
         /// </summary>


### PR DESCRIPTION
## Description
**Describe the changes** 
Overload two operators `==` & `!=` to `Player` class and add `Equals` and `GetHashCode`.
Fix comparison between two player instances.

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
