### PR TITLE
Fix ChangingRoleAndSpawned

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -45,6 +45,7 @@ namespace Exiled.Events.Patches.Events.Player
 
             Label returnLabel = generator.DefineLabel();
             Label continueLabel = generator.DefineLabel();
+            Label continueLabel2 = generator.DefineLabel();
             Label jmp = generator.DefineLabel();
 
             LocalBuilder changingRoleEventArgs = generator.DeclareLocal(typeof(ChangingRoleEventArgs));
@@ -142,10 +143,17 @@ namespace Exiled.Events.Patches.Events.Player
             offset = 1;
             index = newInstructions.FindIndex(i => i.Calls(Method(typeof(PlayerRoleManager.RoleChanged), nameof(PlayerRoleManager.RoleChanged.Invoke)))) + offset;
 
+            newInstructions[index].labels.Add(continueLabel2);
+
             newInstructions.InsertRange(
                 index,
                 new CodeInstruction[]
                 {
+                    // if (changingRoleEventArgs == null)
+                    // skip
+                    new(OpCodes.Ldloc_S, changingRoleEventArgs.LocalIndex),
+                    new(OpCodes.Brfalse_S, continueLabel2),
+
                     // changingRoleEventArgs
                     new(OpCodes.Ldloc_S, changingRoleEventArgs.LocalIndex),
 

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingRoleAndSpawned.cs
@@ -45,7 +45,6 @@ namespace Exiled.Events.Patches.Events.Player
 
             Label returnLabel = generator.DefineLabel();
             Label continueLabel = generator.DefineLabel();
-            Label continueLabel2 = generator.DefineLabel();
             Label jmp = generator.DefineLabel();
 
             LocalBuilder changingRoleEventArgs = generator.DeclareLocal(typeof(ChangingRoleEventArgs));
@@ -143,17 +142,10 @@ namespace Exiled.Events.Patches.Events.Player
             offset = 1;
             index = newInstructions.FindIndex(i => i.Calls(Method(typeof(PlayerRoleManager.RoleChanged), nameof(PlayerRoleManager.RoleChanged.Invoke)))) + offset;
 
-            newInstructions[index].labels.Add(continueLabel2);
-
             newInstructions.InsertRange(
                 index,
                 new CodeInstruction[]
                 {
-                    // if (changingRoleEventArgs == null)
-                    // skip
-                    new(OpCodes.Ldloc_S, changingRoleEventArgs.LocalIndex),
-                    new(OpCodes.Brfalse_S, continueLabel2),
-
                     // changingRoleEventArgs
                     new(OpCodes.Ldloc_S, changingRoleEventArgs.LocalIndex),
 
@@ -194,7 +186,7 @@ namespace Exiled.Events.Patches.Events.Player
         {
             try
             {
-                if (!NetworkServer.active || !ev.SpawnFlags.HasFlag(RoleSpawnFlags.AssignInventory))
+                if (!NetworkServer.active || ev == null || !ev.SpawnFlags.HasFlag(RoleSpawnFlags.AssignInventory))
                 {
                     return;
                 }


### PR DESCRIPTION
## Description
**Describe the changes** 
The eventargs for ChangingRole could be null sometimes (if player not verified), which breaks ChangeInventory method.

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
