### PR TITLE
fix: Null Bug in Issue #206 Fix

### DIFF
--- a/EXILED/Exiled.API/Features/Room.cs
+++ b/EXILED/Exiled.API/Features/Room.cs
@@ -201,9 +201,9 @@ namespace Exiled.API.Features
         internal List<Camera> CamerasValue { get; } = new();
 
         /// <summary>
-        /// Gets a <see cref="List{T}"/> containing all known <see cref="RoomLightController"/>s in that <see cref="Room"/>.
+        /// Gets or sets a <see cref="List{T}"/> containing all known <see cref="RoomLightController"/>s in that <see cref="Room"/>.
         /// </summary>
-        internal List<RoomLightController> RoomLightControllersValue { get; } = new();
+        internal List<RoomLightController> RoomLightControllersValue { get; set; } = new();
 
         /// <summary>
         /// Gets a <see cref="List{T}"/> containing all known <see cref="Room"/>s around that <see cref="Room"/>.
@@ -506,6 +506,9 @@ namespace Exiled.API.Features
             if (Type is RoomType.Unknown)
                 Log.Error($"[ROOMTYPE UNKNOWN] {this} Name : {gameObject?.name} Shape : {Identifier?.Shape}");
 #endif
+
+            if (RoomLightControllersValue.Count == 0)
+                RoomLightControllersValue = new List<RoomLightController>();
 
             RoomLightControllersValue.AddRange(gameObject.GetComponentsInChildren<RoomLightController>());
 

--- a/EXILED/Exiled.Events/Handlers/Internal/Round.cs
+++ b/EXILED/Exiled.Events/Handlers/Internal/Round.cs
@@ -97,12 +97,23 @@ namespace Exiled.Events.Handlers.Internal
         {
             RoleAssigner.CheckLateJoin(ev.Player.ReferenceHub, ClientInstanceMode.ReadyClient);
 
-            // TODO: Remove if this has been fixed for https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/52
-            foreach (Room room in Room.List.Where(current => current.AreLightsOff))
+            foreach (Room room in Room.List)
             {
+                // Null safety check for github issue #206
+                if (room.RoomLightControllers == null)
+                    continue;
+                if (!room.AreLightsOff)
+                    continue;
                 ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), true);
                 ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), false);
             }
+
+            // // TODO: Remove if this has been fixed for https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/52
+            // foreach (Room room in Room.List.Where(current => current.AreLightsOff))
+            // {
+            //     ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), true);
+            //     ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), false);
+            // }
         }
 
         private static void GenerateAttachments()

--- a/EXILED/Exiled.Events/Handlers/Internal/Round.cs
+++ b/EXILED/Exiled.Events/Handlers/Internal/Round.cs
@@ -97,6 +97,7 @@ namespace Exiled.Events.Handlers.Internal
         {
             RoleAssigner.CheckLateJoin(ev.Player.ReferenceHub, ClientInstanceMode.ReadyClient);
 
+            // TODO: Remove if this has been fixed for https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/52
             foreach (Room room in Room.List)
             {
                 // Null safety check for github issue #206
@@ -107,13 +108,6 @@ namespace Exiled.Events.Handlers.Internal
                 ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), true);
                 ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), false);
             }
-
-            // // TODO: Remove if this has been fixed for https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/52
-            // foreach (Room room in Room.List.Where(current => current.AreLightsOff))
-            // {
-            //     ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), true);
-            //     ev.Player.SendFakeSyncVar(room.RoomLightControllerNetIdentity, typeof(RoomLightController), nameof(RoomLightController.NetworkLightsEnabled), false);
-            // }
         }
 
         private static void GenerateAttachments()


### PR DESCRIPTION
…hecks.

## Description
**Describe the changes** 
Fixes the Issue in #206 where RoomLightControllers would be a null value sometimes, resulting in a NRE.

**What is the current behavior?** (You can also link to an open issue here)
Point to #206 

**What is the new behavior?** (if this is a feature change)
- RoomLightControllersValue in Exiled.API/Features/Room.cs will be set to a new List if its count is zero, preventing a null access.
- RoomLightControllers in Exiled.Events\Handlers\Internal\Round.cs while in the for loop to fix SCP:SL Bug 52 (https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/52)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
nope.

**Other information**:
no idea
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected
^ Unable to setup debugging at time of writing due to unity weirdness, but i haven't gotten the error.

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing

