### PR TITLE
New Shot patch

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Player/ShotEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/ShotEventArgs.cs
@@ -27,12 +27,13 @@ namespace Exiled.Events.EventArgs.Player
         /// <param name="destructible">The IDestructible that was hit. Can be null.</param>
         public ShotEventArgs(HitscanHitregModuleBase hitregModule, RaycastHit hitInfo, InventorySystem.Items.Firearms.Firearm firearm, IDestructible destructible)
         {
-            Player = Player.Get(firearm.Owner);
+            HitregModule = hitregModule;
+            RaycastHit = hitInfo;
+            Destructible = destructible;
             Firearm = Item.Get<Firearm>(firearm);
 
-            Damage = hitInfo.collider.TryGetComponent(out IDestructible component) ? hitregModule.DamageAtDistance(hitInfo.distance) : 0f;
-            Destructible = component;
-            RaycastHit = hitInfo;
+            Player = Firearm.Owner;
+            Damage = Destructible is not null ? HitregModule.DamageAtDistance(hitInfo.distance) : 0f;
 
             if (Destructible is HitboxIdentity hitboxIdentity)
             {
@@ -47,12 +48,22 @@ namespace Exiled.Events.EventArgs.Player
         public Player Player { get; }
 
         /// <summary>
-        /// Gets the firearm used to shoot.
+        /// Gets the firearm used to fire the shot.
         /// </summary>
         public Firearm Firearm { get; }
 
         /// <inheritdoc/>
         public Item Item => Firearm;
+
+        /// <summary>
+        /// Gets the firearm hitreg module responsible for the shot.
+        /// </summary>
+        public HitscanHitregModuleBase HitregModule { get; }
+
+        /// <summary>
+        /// Gets the raycast info.
+        /// </summary>
+        public RaycastHit RaycastHit { get; }
 
         /// <summary>
         /// Gets the bullet travel distance.
@@ -65,19 +76,9 @@ namespace Exiled.Events.EventArgs.Player
         public Vector3 Position => RaycastHit.point;
 
         /// <summary>
-        /// Gets the <see cref="IDestructible"/> component of the hit collider. Can be null.
-        /// </summary>
-        public IDestructible Destructible { get; }
-
-        /// <summary>
-        /// Gets the firearm damage at the hit distance. Actual inflicted damage may vary.
+        /// Gets the firearm base damage at the hit distance. Actual inflicted damage may vary.
         /// </summary>
         public float Damage { get; }
-
-        /// <summary>
-        /// Gets the raycast info.
-        /// </summary>
-        public RaycastHit RaycastHit { get; }
 
         /// <summary>
         /// Gets the target player. Can be null.
@@ -85,13 +86,23 @@ namespace Exiled.Events.EventArgs.Player
         public Player Target { get; }
 
         /// <summary>
-        /// Gets the <see cref="HitboxIdentity"/> component of the target player. Can be null.
+        /// Gets the <see cref="HitboxIdentity"/> component of the target player that was hit. Can be null.
         /// </summary>
         public HitboxIdentity Hitbox { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the shot can hurt the target.
+        /// Gets the <see cref="IDestructible"/> component of the hit collider. Can be null.
+        /// </summary>
+        public IDestructible Destructible { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the shot can deal damage.
         /// </summary>
         public bool CanHurt { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the shot can produce impact effects (e.g. bullet holes).
+        /// </summary>
+        public bool CanSpawnImpactEffects { get; set; } = true;
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Player/ShotEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/ShotEventArgs.cs
@@ -19,44 +19,30 @@ namespace Exiled.Events.EventArgs.Player
     public class ShotEventArgs : IPlayerEvent, IFirearmEvent
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShotEventArgs" /> class.
+        /// Initializes a new instance of the <see cref="ShotEventArgs"/> class.
         /// </summary>
-        /// <param name="instance">
-        /// The <see cref="HitscanHitregModuleBase"/> instance.
-        /// </param>
-        /// <param name="firearm">
-        /// <inheritdoc cref="Firearm"/>
-        /// </param>
-        /// <param name="ray">
-        /// <inheritdoc cref="Ray" />
-        /// </param>
-        /// <param name="maxDistance">
-        /// <inheritdoc cref="MaxDistance" />
-        /// </param>
-        public ShotEventArgs(HitscanHitregModuleBase instance, InventorySystem.Items.Firearms.Firearm firearm, Ray ray, float maxDistance)
+        /// <param name="hitregModule">Hitreg module that calculated the shot.</param>
+        /// <param name="hitInfo">Raycast hit info.</param>
+        /// <param name="firearm">The firearm used.</param>
+        /// <param name="destructible">The IDestructible that was hit. Can be null.</param>
+        public ShotEventArgs(HitscanHitregModuleBase hitregModule, RaycastHit hitInfo, InventorySystem.Items.Firearms.Firearm firearm, IDestructible destructible)
         {
             Player = Player.Get(firearm.Owner);
             Firearm = Item.Get<Firearm>(firearm);
-            MaxDistance = maxDistance;
 
-            if (!Physics.Raycast(ray, out RaycastHit hitInfo, maxDistance, HitscanHitregModuleBase.HitregMask))
-                return;
-
-            Distance = hitInfo.distance;
-            Position = hitInfo.point;
-            Damage = hitInfo.collider.TryGetComponent(out IDestructible component) ? instance.DamageAtDistance(hitInfo.distance) : 0f;
+            Damage = hitInfo.collider.TryGetComponent(out IDestructible component) ? hitregModule.DamageAtDistance(hitInfo.distance) : 0f;
             Destructible = component;
             RaycastHit = hitInfo;
 
-            if (component is HitboxIdentity identity)
+            if (Destructible is HitboxIdentity hitboxIdentity)
             {
-                Hitbox = identity;
+                Hitbox = hitboxIdentity;
                 Target = Player.Get(Hitbox.TargetHub);
             }
         }
 
         /// <summary>
-        /// Gets the player who shot.
+        /// Gets the player who fired the shot.
         /// </summary>
         public Player Player { get; }
 
@@ -69,43 +55,43 @@ namespace Exiled.Events.EventArgs.Player
         public Item Item => Firearm;
 
         /// <summary>
-        /// Gets the max distance of the shot.
+        /// Gets the bullet travel distance.
         /// </summary>
-        public float MaxDistance { get;  }
+        public float Distance => RaycastHit.distance;
 
         /// <summary>
-        /// Gets the shot distance. Can be <c>0.0f</c> if the raycast doesn't hit collider.
+        /// Gets the position of the hit.
         /// </summary>
-        public float Distance { get; }
+        public Vector3 Position => RaycastHit.point;
 
         /// <summary>
-        /// Gets the shot position. Can be <see langword="null"/> if the raycast doesn't hit collider.
-        /// </summary>
-        public Vector3 Position { get; }
-
-        /// <summary>
-        /// Gets the <see cref="IDestructible"/> component of the hit collider. Can be <see langword="null"/>.
+        /// Gets the <see cref="IDestructible"/> component of the hit collider. Can be null.
         /// </summary>
         public IDestructible Destructible { get; }
 
         /// <summary>
-        /// Gets the inflicted damage.
+        /// Gets the firearm damage at the hit distance. Actual inflicted damage may vary.
         /// </summary>
         public float Damage { get; }
 
         /// <summary>
-        /// Gets the raycast result.
+        /// Gets the raycast info.
         /// </summary>
         public RaycastHit RaycastHit { get; }
 
         /// <summary>
-        /// Gets the target of the shot. Can be <see langword="null"/>.
+        /// Gets the target player. Can be null.
         /// </summary>
         public Player Target { get; }
 
         /// <summary>
-        /// Gets the <see cref="HitboxIdentity"/> component of the hit collider. Can be <see langword="null"/>.
+        /// Gets the <see cref="HitboxIdentity"/> component of the target player. Can be null.
         /// </summary>
         public HitboxIdentity Hitbox { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the shot can hurt the target.
+        /// </summary>
+        public bool CanHurt { get; set; } = true;
     }
 }

--- a/EXILED/Exiled.Events/Patches/Events/Player/Shot.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/Shot.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Patches.Events.Player
 {
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Reflection.Emit;
 
     using API.Features.Pools;
@@ -15,6 +16,7 @@ namespace Exiled.Events.Patches.Events.Player
     using Exiled.Events.EventArgs.Player;
     using HarmonyLib;
     using InventorySystem.Items.Firearms.Modules;
+    using UnityEngine;
 
     using static HarmonyLib.AccessTools;
 
@@ -26,40 +28,84 @@ namespace Exiled.Events.Patches.Events.Player
     [HarmonyPatch(typeof(HitscanHitregModuleBase), nameof(HitscanHitregModuleBase.ServerPerformHitscan))]
     internal static class Shot
     {
+        private static void ProcessRaycastMiss(HitscanHitregModuleBase hitregModule, Ray ray, float maxDistance)
+        {
+            RaycastHit hit = new()
+            {
+                distance = maxDistance,
+                point = ray.GetPoint(maxDistance),
+                normal = -ray.direction,
+            };
+
+            var ev = new ShotEventArgs(hitregModule, hit, hitregModule.Firearm, null);
+            Handlers.Player.OnShot(ev);
+        }
+
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
 
-            Label returnLabel = generator.DefineLabel();
-
-            int offset = 3;
-            int index = newInstructions.FindIndex(x => x.opcode == OpCodes.Ldarg_2) + offset;
+            /*
+            IL_0020: ldarg.1      // targetRay
+            IL_0021: ldloca.s     hitInfo
+            IL_0023: ldloc.0      // maxDistance
+            IL_0024: ldsfld       class CachedLayerMask InventorySystem.Items.Firearms.Modules.HitscanHitregModuleBase::HitregMask
+            IL_0029: call         int32 CachedLayerMask::op_Implicit(class CachedLayerMask)
+            IL_002e: call         bool [UnityEngine.PhysicsModule]UnityEngine.Physics::Raycast(valuetype [UnityEngine.CoreModule]UnityEngine.Ray, valuetype [UnityEngine.PhysicsModule]UnityEngine.RaycastHit&, float32, int32)
+            IL_0033: brtrue.s     IL_0037
+            [] <= Here
+             */
+            MethodInfo raycastMethod = Method(typeof(Physics), nameof(Physics.Raycast), new[] { typeof(Ray), typeof(RaycastHit).MakeByRefType(), typeof(float), typeof(int) });
+            int raycastFailIndex = newInstructions.FindIndex(i => i.Calls(raycastMethod)) + 2;
 
             newInstructions.InsertRange(
-                index,
+                raycastFailIndex,
                 new CodeInstruction[]
                 {
-                    // instance
+                    // ProcessRaycastMiss(this, targetRay, maxDistance);
                     new(OpCodes.Ldarg_0),
-
-                    // this.Firearm
-                    new(OpCodes.Ldarg_0),
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(HitscanHitregModuleBase), nameof(HitscanHitregModuleBase.Firearm))),
-
-                    // ray
                     new(OpCodes.Ldarg_1),
-
-                    // maxDistance
                     new(OpCodes.Ldloc_0),
-
-                    // ShotEventArgs ev = new(HitscanHitregModuleBase, Firearm, Ray, float)
-                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ShotEventArgs))[0]),
-
-                    // Handlers.Player.OnShot(ev)
-                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnShot))),
+                    new(OpCodes.Call, Method(typeof(Shot), nameof(ProcessRaycastMiss))),
                 });
 
-            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+            /*
+            IL_0037: ldloca.s     hitInfo
+            IL_0039: call         instance class [UnityEngine.PhysicsModule]UnityEngine.Collider [UnityEngine.PhysicsModule]UnityEngine.RaycastHit::get_collider()
+            IL_003e: ldloca.s     component
+            IL_0040: callvirt     instance bool [UnityEngine.CoreModule]UnityEngine.Component::TryGetComponent<class IDestructible>(!!0/*class IDestructible* /&)
+            [] <= Here  // This position is reached whether IDestructible is found or not.
+            IL_0045: brfalse.s    IL_005e
+             */
+            int destructibleGetIndex = newInstructions.FindIndex(i => i.Calls(Method(typeof(Component), nameof(Component.TryGetComponent))));
+
+            Label continueLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(
+                destructibleGetIndex + 1,
+                new[]
+                {
+                    // var ev = new ShotEventArgs(this, hit, firearm, component);
+                    new(OpCodes.Ldarg_0), // this
+                    new(OpCodes.Ldloc_1), // hit
+                    new(OpCodes.Ldarg_0), // this.Firearm
+                    new(OpCodes.Ldloc_2), // component
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(HitscanHitregModuleBase), nameof(HitscanHitregModuleBase.Firearm))),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ShotEventArgs))[0]),
+
+                    new(OpCodes.Dup), // Leave ShotEventArgs on the stack
+                    new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnShot))),
+
+                    // if (!ev.CanHurt) hitInfo.distance = float.MaxValue;
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ShotEventArgs), nameof(ShotEventArgs.CanHurt))),
+                    new(OpCodes.Brtrue, continueLabel),
+
+                    new(OpCodes.Ldloc_1), // hitInfo
+                    new(OpCodes.Ldc_R4, float.MaxValue), // float.MaxValue
+                    new(OpCodes.Stfld, Field(typeof(RaycastHit), nameof(RaycastHit.distance))), // hitInfo.distance = float.MaxValue
+
+                    new CodeInstruction(OpCodes.Nop).WithLabels(continueLabel),
+                });
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];


### PR DESCRIPTION
## Description
**Describe the changes** 
Added new Shot patch

**What is the current behavior?** (You can also link to an open issue here)
Current Shot patch is using Physics.Raycast in its constructor and is missing crucial CanHurt field that is widely used in plugins

**What is the new behavior?** (if this is a feature change)
Mentioned issues are fixed

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, it removes MaxDistance field from ShotEventArgs. This field is just as relevant as including raycast mask in the event (not at all)

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
