### PR TITLE
fix: `OnAdded` called after event

### DIFF
--- a/EXILED/Exiled.Events/Patches/Fixes/FixOnAddedBeingCallAfterOnRemoved.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/FixOnAddedBeingCallAfterOnRemoved.cs
@@ -12,11 +12,15 @@ namespace Exiled.Events.Patches.Fixes
     using System.Reflection.Emit;
 
     using API.Features.Pools;
-    using Exiled.API.Features;
+
     using HarmonyLib;
+
     using InventorySystem;
     using InventorySystem.Items;
+    using InventorySystem.Items.Firearms.Ammo;
     using InventorySystem.Items.Pickups;
+
+    using Mirror;
 
     using static HarmonyLib.AccessTools;
 
@@ -30,36 +34,52 @@ namespace Exiled.Events.Patches.Fixes
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
-            /*
-                // Modify this
-                itemBase2.OnAdded(pickup);
-                Action<ReferenceHub, ItemBase, ItemPickupBase> onItemAdded = InventoryExtensions.OnItemAdded;
-                if (onItemAdded != null)
-                {
-                    onItemAdded(inv._hub, itemBase2, pickup);
-                }
-                // To this
-                Action<ReferenceHub, ItemBase, ItemPickupBase> onItemAdded = InventoryExtensions.OnItemAdded;
-                if (onItemAdded != null)
-                {
-                    onItemAdded(inv._hub, itemBase2, pickup);
-                }
-                itemBase2.OnAdded(pickup);
-             */
-            int opCodesToMove = 3;
-            int offset = -2;
-            int indexOnAdded = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(ItemBase), nameof(ItemBase.OnAdded)))) + offset;
 
-            offset = 1;
-            int indexInvoke = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(Action<ReferenceHub, ItemBase, ItemPickupBase>), nameof(Action<ReferenceHub, ItemBase, ItemPickupBase>.Invoke)))) + offset;
+            Label continueLabel = generator.DefineLabel();
 
-            newInstructions.InsertRange(indexInvoke, newInstructions.GetRange(indexOnAdded, opCodesToMove));
-            newInstructions[indexInvoke].MoveLabelsFrom(newInstructions[indexInvoke + opCodesToMove]);
-            newInstructions.RemoveRange(indexOnAdded, opCodesToMove);
+            int offset = -1;
+            int index = newInstructions.FindLastIndex(instruction => instruction.Calls(PropertyGetter(typeof(NetworkBehaviour), nameof(NetworkBehaviour.isLocalPlayer)))) + offset;
+
+            // set label for code right after OnAdded/OnItemAdded, to skip that part for ammo
+            Label afterAmmoLabel = newInstructions[index].labels[0];
+
+            offset = -2;
+            index = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(ItemBase), nameof(ItemBase.OnAdded)))) + offset;
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    // if (itemBase is not AmmoItem)
+                    //     skip;
+                    new CodeInstruction(OpCodes.Ldloc_1),
+                    new(OpCodes.Isinst, typeof(AmmoItem)),
+                    new(OpCodes.Brfalse_S, continueLabel),
+
+                    // call help method for inverse call
+                    // InverseCall(itemBase, inv._hub, pickup)
+                    new(OpCodes.Ldloc_1),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(Inventory), nameof(Inventory._hub))),
+                    new(OpCodes.Ldarg_S, 4),
+                    new(OpCodes.Call, Method(typeof(FixOnAddedBeingCallAfterOnRemoved), nameof(FixOnAddedBeingCallAfterOnRemoved.InverseCall))),
+
+                    // move after basegame OnAdded/OnItemAdded
+                    new(OpCodes.Br_S, afterAmmoLabel),
+
+                    new CodeInstruction(OpCodes.Nop).WithLabels(continueLabel),
+                });
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];
+
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+
+        private static void InverseCall(ItemBase item, ReferenceHub referenceHub, ItemPickupBase pickup)
+        {
+            Exiled.API.Extensions.ReflectionExtensions.InvokeStaticEvent(typeof(InventoryExtensions), nameof(InventoryExtensions.OnItemAdded), new object[] { referenceHub, item, pickup });
+            item.OnAdded(pickup);
         }
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
Because we replace OnAdded/OnItemAdded calls, for example we cant set ammo for firearms in `ReadPickupItem`, and overall that logic is cringe, call `OnItemAdded` before `OnAdded` - actual item initialization.

**What is the current behavior?** (You can also link to an open issue here)
for all items - call `OnItemAdded` event before `OnAdded`

**What is the new behavior?** (if this is a feature change)
for ammoitems - call `OnItemAdded` event before `OnAdded`
for other - normal

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
🤷‍♂️

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
