### PR TITLE
Fix DroppingCandy event

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Scp330/DroppingScp330EventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp330/DroppingScp330EventArgs.cs
@@ -39,9 +39,9 @@ namespace Exiled.Events.EventArgs.Scp330
         }
 
         /// <summary>
-        /// Gets or sets a value representing the <see cref="API.Features.Items.Item" /> being picked up.
+        /// Gets a value representing the <see cref="API.Features.Items.Item" /> being picked up.
         /// </summary>
-        public Scp330 Scp330 { get; set; } // Todo Remove set
+        public Scp330 Scp330 { get; }
 
         /// <inheritdoc/>
         public Item Item => Scp330;

--- a/EXILED/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp330/DroppingCandy.cs
@@ -56,15 +56,14 @@ namespace Exiled.Events.Patches.Events.Scp330
 
                     // scp330Bag
                     new(OpCodes.Ldloc_1),
-
-                    // Load candy bag array to get CandyKindID
                     new(OpCodes.Dup),
-                    new(OpCodes.Ldfld, Field(typeof(Scp330Bag), nameof(Scp330Bag.Candies))),
-                    new(OpCodes.Ldarg_1),
 
-                    // Grab candy ID from network message, and pass it to event args.
+                    // msg.CandyID
+                    new(OpCodes.Ldarg_1),
                     new(OpCodes.Ldfld, Field(typeof(SelectScp330Message), nameof(SelectScp330Message.CandyID))),
-                    new(OpCodes.Ldelem_U1),
+
+                    // CandyKindID
+                    new(OpCodes.Call, Method(typeof(DroppingCandy), nameof(DroppingCandy.GetCandyID))),
 
                     // DroppingScp330EventArgs ev = new(Player, Scp330Bag, CandyKindID)
                     new(OpCodes.Newobj, GetDeclaredConstructors(typeof(DroppingScp330EventArgs))[0]),
@@ -104,6 +103,13 @@ namespace Exiled.Events.Patches.Events.Scp330
                 yield return newInstructions[z];
 
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+
+        private static CandyKindID GetCandyID(Scp330Bag scp330Bag, int index)
+        {
+            if (index < 0 || index > scp330Bag.Candies.Count)
+                return CandyKindID.None;
+            return scp330Bag.Candies[index];
         }
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
Remove Scp330Bag setter and fix ev.Candy always None.

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
