### PR TITLE
Fix EndingRound event

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Server/EndingRoundEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Server/EndingRoundEventArgs.cs
@@ -7,8 +7,6 @@
 
 namespace Exiled.Events.EventArgs.Server
 {
-    using System;
-
     using API.Enums;
     using Interfaces;
 
@@ -23,21 +21,18 @@ namespace Exiled.Events.EventArgs.Server
         /// <param name="classList">
         /// <inheritdoc cref="RoundSummary.SumInfo_ClassList" />
         /// </param>
-        /// <param name="leadingTeam">
-        /// <inheritdoc cref="LeadingTeam" />
-        /// </param>
-        /// <param name="isAllowed">
-        /// <inheritdoc cref="IsRoundEnded" />
-        /// </param>
         /// <param name="isForceEnded">
         /// <inheritdoc cref="IsForceEnded" />
         /// </param>
-        public EndingRoundEventArgs(RoundSummary.LeadingTeam leadingTeam, RoundSummary.SumInfo_ClassList classList, bool isAllowed, bool isForceEnded)
+        /// <param name="isAllowed">
+        /// <inheritdoc cref="IsAllowed" />
+        /// </param>
+        public EndingRoundEventArgs(RoundSummary.SumInfo_ClassList classList, bool isForceEnded, bool isAllowed)
         {
             ClassList = classList;
-            LeadingTeam = (LeadingTeam)leadingTeam;
-            IsRoundEnded = isAllowed;
+            LeadingTeam = GetLeadingTeam(classList);
             IsForceEnded = isForceEnded;
+            IsAllowed = isAllowed;
         }
 
         /// <summary>
@@ -51,22 +46,33 @@ namespace Exiled.Events.EventArgs.Server
         public LeadingTeam LeadingTeam { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the round is going to finish.
-        /// </summary>
-        public bool IsRoundEnded { get; set; } // TODO: Obsolete this in Exiled 10
-
-        /// <summary>
-        /// Gets or Sets a value indicating whether the round is ended by API call.
+        /// Gets or sets a value indicating whether the round is ended by API call.
         /// </summary>
         public bool IsForceEnded { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the event can be executed.
+        /// Gets or sets a value indicating whether the round is going to finish or not.
         /// </summary>
-        public bool IsAllowed
+        public bool IsAllowed { get; set; }
+
+        private LeadingTeam GetLeadingTeam(RoundSummary.SumInfo_ClassList classList)
         {
-            get => IsRoundEnded;
-            set => IsRoundEnded = value;
+            // NW logic
+            int facilityForces = classList.mtf_and_guards + classList.scientists;
+            int chaosInsurgency = classList.chaos_insurgents + classList.class_ds;
+            int anomalies = classList.scps_except_zombies + classList.zombies;
+            int num4 = facilityForces > 0 ? 1 : 0;
+            bool flag1 = chaosInsurgency > 0;
+            bool flag2 = anomalies > 0;
+            RoundSummary.LeadingTeam leadingTeam = RoundSummary.LeadingTeam.Draw;
+            if (num4 != 0)
+                leadingTeam = RoundSummary.EscapedScientists >= RoundSummary.EscapedClassD ? RoundSummary.LeadingTeam.FacilityForces : RoundSummary.LeadingTeam.Draw;
+            else if (flag2 || flag2 & flag1)
+                leadingTeam = RoundSummary.EscapedClassD > RoundSummary.SurvivingSCPs ? RoundSummary.LeadingTeam.ChaosInsurgency : (RoundSummary.SurvivingSCPs > RoundSummary.EscapedScientists ? RoundSummary.LeadingTeam.Anomalies : RoundSummary.LeadingTeam.Draw);
+            else if (flag1)
+                leadingTeam = RoundSummary.EscapedClassD >= RoundSummary.EscapedScientists ? RoundSummary.LeadingTeam.ChaosInsurgency : RoundSummary.LeadingTeam.Draw;
+
+            return (LeadingTeam)leadingTeam;
         }
-}
+    }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
- Replace base game logic with `LeadingTeam leadingTeam = ev.LeadingTeam`
  - This fix getter & setter of ev.LeadingTeam
- Remove IsRoundEnded (IsAllowed do the same)

**What is the current behavior?** (You can also link to an open issue here)
- ev.LeadingTeam always return FacilityForces (represents 0)
- ev.LeadingTeam setter doesn't work
- unneeded property in the event

**What is the new behavior?** (if this is a feature change)
- ev.LeadingTeam return the correct LeadingTeam
- set ev.LeadingTeam change the team that win the round
- IsRoundEnded is now IsAllowed

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
