### PR TITLE
fix: fix respawning and selecting team events that make server crash

### DIFF
--- a/EXILED/Exiled.API/Features/Waves/TimedWave.cs
+++ b/EXILED/Exiled.API/Features/Waves/TimedWave.cs
@@ -21,40 +21,43 @@ namespace Exiled.API.Features.Waves
     /// </summary>
     public class TimedWave
     {
-        private readonly TimeBasedWave timedWave;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TimedWave"/> class.
         /// </summary>
         /// <param name="wave">
         /// The <see cref="TimeBasedWave"/> that this class should be based off of.
         /// </param>
-        public TimedWave(TimeBasedWave wave) => timedWave = wave;
+        public TimedWave(TimeBasedWave wave) => Base = wave;
+
+        /// <summary>
+        /// Gets the base <see cref="TimeBasedWave"/>.
+        /// </summary>
+        public TimeBasedWave Base { get; }
 
         /// <summary>
         /// Gets the name of the wave timer.
         /// </summary>
-        public string Name => timedWave.GetType().Name;
+        public string Name => Base.GetType().Name;
 
         /// <summary>
         /// Gets a value indicating whether the wave is a mini wave.
         /// </summary>
-        public bool IsMiniWave => timedWave is IMiniWave;
+        public bool IsMiniWave => Base is IMiniWave;
 
         /// <summary>
         /// Gets the wave timer instance.
         /// </summary>
-        public WaveTimer Timer => new(timedWave.Timer);
+        public WaveTimer Timer => new(Base.Timer);
 
         /// <summary>
         /// Gets the faction of this wave.
         /// </summary>
-        public Faction Faction => timedWave.TargetFaction;
+        public Faction Faction => Base.TargetFaction;
 
         /// <summary>
         /// Gets the team of this wave.
         /// </summary>
-        public Team Team => timedWave.TargetFaction.GetSpawnableTeam();
+        public Team Team => Base.TargetFaction.GetSpawnableTeam();
 
         /// <summary>
         /// Gets the spawnable faction for this wave.
@@ -70,13 +73,13 @@ namespace Exiled.API.Features.Waves
         /// <summary>
         /// Gets the maximum amount of people that can spawn in this wave.
         /// </summary>
-        public int MaxAmount => timedWave.MaxWaveSize;
+        public int MaxAmount => Base.MaxWaveSize;
 
         /// <summary>
         /// Gets the <see cref="WaveAnnouncementBase"/> for this wave.
         /// </summary>
         /// <remarks>Wave must implement <see cref="IAnnouncedWave"/>.</remarks>
-        public WaveAnnouncementBase Announcement => timedWave is IAnnouncedWave announcedWave ? announcedWave.Announcement : null;
+        public WaveAnnouncementBase Announcement => Base is IAnnouncedWave announcedWave ? announcedWave.Announcement : null;
 
         /// <summary>
         /// Get the timed waves for the specified faction.
@@ -142,7 +145,7 @@ namespace Exiled.API.Features.Waves
                 if (waveBase is not TimeBasedWave timeWave || timeWave.GetType() != typeof(T))
                     continue;
 
-                wave = new(timeWave);
+                wave = new TimedWave(timeWave);
                 return true;
             }
 
@@ -163,7 +166,7 @@ namespace Exiled.API.Features.Waves
             {
                 if (wave is TimeBasedWave timeBasedWave)
                 {
-                    waves.Add(new (timeBasedWave));
+                    waves.Add(new TimedWave(timeBasedWave));
                 }
             }
 
@@ -173,7 +176,7 @@ namespace Exiled.API.Features.Waves
         /// <summary>
         /// Destroys this wave.
         /// </summary>
-        public void Destroy() => timedWave.Destroy();
+        public void Destroy() => Base.Destroy();
 
         /// <summary>
         /// Populates this wave with the specified amount of roles.
@@ -184,7 +187,7 @@ namespace Exiled.API.Features.Waves
         /// <param name="amount">
         /// The amount of people to populate.
         /// </param>
-        public void PopulateQueue(Queue<RoleTypeId> queue, int amount) => timedWave.PopulateQueue(queue, amount);
+        public void PopulateQueue(Queue<RoleTypeId> queue, int amount) => Base.PopulateQueue(queue, amount);
 
         /// <summary>
         /// Plays the announcement for this wave.

--- a/EXILED/Exiled.API/Features/Waves/WaveTimer.cs
+++ b/EXILED/Exiled.API/Features/Waves/WaveTimer.cs
@@ -25,70 +25,70 @@ namespace Exiled.API.Features.Waves
     public class WaveTimer
     {
         /// <summary>
-        /// Get the native <see cref="Respawning.Waves.WaveTimer"/>.
-        /// </summary>
-        private readonly Respawning.Waves.WaveTimer waveTimer;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="WaveTimer"/> class.
         /// </summary>
         /// <param name="wave">The <see cref="Respawning.Waves.WaveTimer"/> that this class should be based off of.</param>
-        public WaveTimer(Respawning.Waves.WaveTimer wave) => waveTimer = wave;
+        public WaveTimer(Respawning.Waves.WaveTimer wave) => Base = wave;
+
+        /// <summary>
+        /// Gets the base <see cref="Respawning.Waves.WaveTimer"/>.
+        /// </summary>
+        public Respawning.Waves.WaveTimer Base { get; }
 
         /// <summary>
         /// Gets the name of the wave timer.
         /// </summary>
-        public string Name => waveTimer._wave.GetType().Name;
+        public string Name => Base._wave.GetType().Name;
 
         /// <summary>
         /// Gets a value indicating whether the wave is a mini wave.
         /// </summary>
-        public bool IsMiniWave => waveTimer._wave is IMiniWave;
+        public bool IsMiniWave => Base._wave is IMiniWave;
 
         /// <summary>
         /// Gets the amount of time left before the wave spawns.
         /// </summary>
-        public TimeSpan TimeLeft => TimeSpan.FromSeconds(waveTimer.TimeLeft);
+        public TimeSpan TimeLeft => TimeSpan.FromSeconds(Base.TimeLeft);
 
         /// <summary>
         /// Gets the amount of time passed since the last wave spawned.
         /// </summary>
-        public TimeSpan TimePassed => TimeSpan.FromSeconds(waveTimer.TimePassed);
+        public TimeSpan TimePassed => TimeSpan.FromSeconds(Base.TimePassed);
 
         /// <summary>
         /// Gets the amount of time left before this wave unpause.
         /// </summary>
-        public TimeSpan PauseTimeLeft => TimeSpan.FromSeconds(waveTimer.PauseTimeLeft);
+        public TimeSpan PauseTimeLeft => TimeSpan.FromSeconds(Base.PauseTimeLeft);
 
         /// <summary>
         /// Gets the amount of time this wave has been paused for.
         /// </summary>
-        public TimeSpan PausedFor => TimeSpan.FromSeconds(waveTimer._pauseTimer);
+        public TimeSpan PausedFor => TimeSpan.FromSeconds(Base._pauseTimer);
 
         /// <summary>
         /// Gets a value indicating whether this wave is paused.
         /// </summary>
-        public bool IsPaused => waveTimer.IsPaused;
+        public bool IsPaused => Base.IsPaused;
 
         /// <summary>
         /// Gets a value indicating whether this wave is ready to spawn.
         /// </summary>
-        public bool IsReady => waveTimer.IsReadyToSpawn;
+        public bool IsReady => Base.IsReadyToSpawn;
 
         /// <summary>
         /// Gets a value indicating whether this wave is out of respawns.
         /// </summary>
-        public bool IsRespawnable => !waveTimer.IsOutOfRespawns;
+        public bool IsRespawnable => !Base.IsOutOfRespawns;
 
         /// <summary>
         /// Gets the default amount of time between a respawn of this wave.
         /// </summary>
-        public float DefaultSpawnInterval => waveTimer.DefaultSpawnInterval;
+        public float DefaultSpawnInterval => Base.DefaultSpawnInterval;
 
         /// <summary>
         /// Gets the actual amount of time between a respawn of this wave.
         /// </summary>
-        public float SpawnInterval => waveTimer.SpawnIntervalSeconds;
+        public float SpawnInterval => Base.SpawnIntervalSeconds;
 
         /// <summary>
         /// Get the wave timers for the specified faction.
@@ -138,7 +138,7 @@ namespace Exiled.API.Features.Waves
         /// <summary>
         /// Destroys this wave timer.
         /// </summary>
-        public void Destroy() => waveTimer.Destroy();
+        public void Destroy() => Base.Destroy();
 
         /// <summary>
         /// Pauses this wave timer.
@@ -146,12 +146,12 @@ namespace Exiled.API.Features.Waves
         /// <param name="seconds">
         /// The amount of time to pause this wave timer for.
         /// </param>
-        public void Pause(float seconds) => waveTimer.Pause(seconds);
+        public void Pause(float seconds) => Base.Pause(seconds);
 
         /// <summary>
         /// Unpauses this wave timer.
         /// </summary>
-        public void Unpause() => waveTimer.Pause(0);
+        public void Unpause() => Base.Pause(0);
 
         /// <summary>
         /// Resets this wave timer.
@@ -159,12 +159,12 @@ namespace Exiled.API.Features.Waves
         /// <param name="resetInterval">
         /// A value indicating whether the <see cref="SpawnInterval"/> should be reset.
         /// </param>
-        public void Reset(bool resetInterval = true) => waveTimer.Reset(resetInterval);
+        public void Reset(bool resetInterval = true) => Base.Reset(resetInterval);
 
         /// <summary>
         /// Update the timer.
         /// </summary>
-        public void Update() => waveTimer.Update();
+        public void Update() => Base.Update();
 
         /// <summary>
         /// Add time to the wave timer.
@@ -172,7 +172,7 @@ namespace Exiled.API.Features.Waves
         /// <param name="seconds">
         /// The amount of time to add in seconds.
         /// </param>
-        public void AddTime(float seconds) => waveTimer.AddTime(seconds);
+        public void AddTime(float seconds) => Base.AddTime(seconds);
 
         /// <summary>
         /// Set the amount of time before the wave spawns.
@@ -188,6 +188,6 @@ namespace Exiled.API.Features.Waves
         /// <param name="seconds">
         /// The amount of time before the wave spawns, in seconds.
         /// </param>
-        public void SetTime(float seconds) => waveTimer.SetTime(seconds);
+        public void SetTime(float seconds) => Base.SetTime(seconds);
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Server/SelectingRespawnTeamEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Server/SelectingRespawnTeamEventArgs.cs
@@ -37,6 +37,6 @@ namespace Exiled.Events.EventArgs.Server
         public TimedWave Wave { get; set; }
 
         /// <inheritdoc/>
-        public bool IsAllowed { get; set; }
+        public bool IsAllowed { get; set; } = true;
     }
 }

--- a/EXILED/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
@@ -93,7 +93,7 @@ namespace Exiled.Events.Patches.Events.Server
                     new(OpCodes.Call, Method(typeof(RespawningTeam), nameof(GetHubs))),
                     new(OpCodes.Stloc_S, 2),
 
-                    // wave = ev.Wave;
+                    // wave = ev.Wave.Base;
                     new(OpCodes.Callvirt, PropertyGetter(typeof(RespawningTeamEventArgs), nameof(RespawningTeamEventArgs.Wave))),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(TimedWave), nameof(TimedWave.Base))),
                     new(OpCodes.Starg_S, 0),

--- a/EXILED/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Server/RespawningTeam.cs
@@ -13,7 +13,7 @@ namespace Exiled.Events.Patches.Events.Server
     using System.Reflection.Emit;
 
     using API.Features.Pools;
-
+    using Exiled.API.Features.Waves;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Server;
     using Exiled.Events.Handlers;
@@ -95,6 +95,7 @@ namespace Exiled.Events.Patches.Events.Server
 
                     // wave = ev.Wave;
                     new(OpCodes.Callvirt, PropertyGetter(typeof(RespawningTeamEventArgs), nameof(RespawningTeamEventArgs.Wave))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(TimedWave), nameof(TimedWave.Base))),
                     new(OpCodes.Starg_S, 0),
                 });
 

--- a/EXILED/Exiled.Events/Patches/Events/Server/SelectingRespawnTeam.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Server/SelectingRespawnTeam.cs
@@ -7,18 +7,14 @@
 
 namespace Exiled.Events.Patches.Events.Server
 {
-    using System;
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Reflection.Emit;
 
-    using Exiled.API.Features;
     using Exiled.API.Features.Pools;
+    using Exiled.API.Features.Waves;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Server;
-
     using HarmonyLib;
-
     using Respawning;
 
     using static HarmonyLib.AccessTools;
@@ -56,9 +52,10 @@ namespace Exiled.Events.Patches.Events.Server
                 new(OpCodes.Callvirt, PropertyGetter(typeof(SelectingRespawnTeamEventArgs), nameof(SelectingRespawnTeamEventArgs.IsAllowed))),
                 new(OpCodes.Brfalse_S, returnLabel),
 
-                // SpawnableWaveBase = ev.Wave;
+                // SpawnableWaveBase = ev.Wave.Base;
                 new(OpCodes.Ldloc_S, ev),
                 new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(SelectingRespawnTeamEventArgs), nameof(SelectingRespawnTeamEventArgs.Wave))),
+                new CodeInstruction(OpCodes.Callvirt, PropertyGetter(typeof(TimedWave), nameof(TimedWave.Base))),
                 new(OpCodes.Starg_S, 0),
             });
 


### PR DESCRIPTION
## Description
**Describe the changes** 
* Add `Base` property to `TimedWave` & `WaveTimer`
* Change default property of `IsAllowed` of selecting team event to `true`
* Call `Base` property in each transpiler of the respecting fixed event

**What is the current behavior?** (You can also link to an open issue here)
When you don't change anything, players aren't able to respawn. If you set IsAllowed to true of selecting, the server crashes.

**What is the new behavior?** (if this is a feature change)
Fixed all of these problems.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
