### PR TITLE
fix: fix announcing ntf/chaos entrance events

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Map/AnnouncingChaosEntranceEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Map/AnnouncingChaosEntranceEventArgs.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.Events.EventArgs.Map
 {
+    using System.Text;
+
     using Exiled.API.Features.Waves;
     using Exiled.Events.EventArgs.Interfaces;
     using Respawning.Announcements;
@@ -20,11 +22,11 @@ namespace Exiled.Events.EventArgs.Map
         /// Initializes a new instance of the <see cref="AnnouncingChaosEntranceEventArgs"/> class.
         /// </summary>
         /// <param name="announcement"><inheritdoc cref="Wave"/></param>
-        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public AnnouncingChaosEntranceEventArgs(WaveAnnouncementBase announcement, bool isAllowed = true)
+        /// <param name="builder"><inheritdoc cref="Words"/></param>
+        public AnnouncingChaosEntranceEventArgs(WaveAnnouncementBase announcement, StringBuilder builder)
         {
             Wave = TimedWave.GetTimedWaves().Find(x => x.Announcement == announcement);
-            IsAllowed = isAllowed;
+            Words = builder;
         }
 
         /// <summary>
@@ -32,7 +34,13 @@ namespace Exiled.Events.EventArgs.Map
         /// </summary>
         public TimedWave Wave { get; }
 
+        /// <summary>
+        /// Gets the <see cref="StringBuilder"/> of the words that C.A.S.S.I.E will say.
+        /// <remarks>It doesn't affect the subtitle part that will be sent to the client.</remarks>
+        /// </summary>
+        public StringBuilder Words { get; }
+
         /// <inheritdoc/>
-        public bool IsAllowed { get; set; }
+        public bool IsAllowed { get; set; } = true;
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Map/AnnouncingNtfEntranceEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Map/AnnouncingNtfEntranceEventArgs.cs
@@ -7,7 +7,9 @@
 
 namespace Exiled.Events.EventArgs.Map
 {
+    using Exiled.API.Features.Waves;
     using Interfaces;
+    using Respawning.Announcements;
 
     /// <summary>
     /// Contains all information before C.A.S.S.I.E announces the NTF entrance.
@@ -17,25 +19,22 @@ namespace Exiled.Events.EventArgs.Map
         /// <summary>
         /// Initializes a new instance of the <see cref="AnnouncingNtfEntranceEventArgs" /> class.
         /// </summary>
-        /// <param name="scpsLeft">
-        /// <inheritdoc cref="ScpsLeft" />
-        /// </param>
-        /// <param name="unitName">
-        /// <inheritdoc cref="UnitName" />
-        /// </param>
-        /// <param name="unitNumber">
-        /// <inheritdoc cref="UnitNumber" />
-        /// </param>
-        /// <param name="isAllowed">
-        /// <inheritdoc cref="IsAllowed" />
-        /// </param>
-        public AnnouncingNtfEntranceEventArgs(int scpsLeft, string unitName, int unitNumber, bool isAllowed = true)
+        /// <param name="announcement"><inheritdoc cref="Wave"/></param>
+        /// <param name="scpsLeft"><inheritdoc cref="ScpsLeft"/></param>
+        /// <param name="unitName"><inheritdoc cref="UnitName"/></param>
+        /// <param name="unitNumber"><inheritdoc cref="UnitNumber"/></param>
+        public AnnouncingNtfEntranceEventArgs(WaveAnnouncementBase announcement, int scpsLeft, string unitName, int unitNumber)
         {
+            Wave = TimedWave.GetTimedWaves().Find(x => x.Announcement == announcement);
             ScpsLeft = scpsLeft;
             UnitName = unitName;
             UnitNumber = unitNumber;
-            IsAllowed = isAllowed;
         }
+
+        /// <summary>
+        /// Gets the entering wave.
+        /// </summary>
+        public TimedWave Wave { get; }
 
         /// <summary>
         /// Gets or sets the number of SCPs left.
@@ -55,6 +54,6 @@ namespace Exiled.Events.EventArgs.Map
         /// <summary>
         /// Gets or sets a value indicating whether the NTF spawn will be announced by C.A.S.S.I.E.
         /// </summary>
-        public bool IsAllowed { get; set; } // TODO possibly not working
+        public bool IsAllowed { get; set; } = true;
     }
 }

--- a/EXILED/Exiled.Events/Patches/Events/Map/AnnouncingChaosEntrance.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Map/AnnouncingChaosEntrance.cs
@@ -8,7 +8,9 @@
 namespace Exiled.Events.Patches.Events.Map
 {
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Reflection.Emit;
+    using System.Text;
 
     using Exiled.API.Features.Pools;
     using Exiled.Events.Attributes;
@@ -23,32 +25,55 @@ namespace Exiled.Events.Patches.Events.Map
     /// to add <see cref="Handlers.Map.AnnouncingChaosEntrance"/> event.
     /// </summary>
     [EventPatch(typeof(Handlers.Map), nameof(Handlers.Map.AnnouncingChaosEntrance))]
-    [HarmonyPatch(typeof(ChaosWaveAnnouncement), nameof(ChaosWaveAnnouncement.CreateAnnouncementString))]
-    [HarmonyPatch(typeof(ChaosMiniwaveAnnouncement), nameof(ChaosMiniwaveAnnouncement.CreateAnnouncementString))]
+    [HarmonyPatch]
     internal static class AnnouncingChaosEntrance
     {
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return Method(typeof(ChaosWaveAnnouncement), nameof(ChaosWaveAnnouncement.CreateAnnouncementString));
+            yield return Method(typeof(ChaosMiniwaveAnnouncement), nameof(ChaosMiniwaveAnnouncement.CreateAnnouncementString));
+        }
+
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instruction, ILGenerator generator)
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instruction);
 
-            Label returnLabel = generator.DefineLabel();
+            Label continueLabel = generator.DefineLabel();
 
-            newInstructions.InsertRange(0, new CodeInstruction[]
+            LocalBuilder ev = generator.DeclareLocal(typeof(AnnouncingChaosEntranceEventArgs));
+
+            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Ldloca_S);
+
+            newInstructions.InsertRange(index, new[]
             {
+                // WaveAnnouncementBase
                 new(OpCodes.Ldarg_0),
 
-                new(OpCodes.Ldc_I4_1),
+                // builder
+                new(OpCodes.Ldarg_1),
 
+                // new AnnouncingChaosEntranceEventArgs(WaveAnnouncementBase, StringBuilder)
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AnnouncingChaosEntranceEventArgs))[0]),
                 new(OpCodes.Dup),
+                new(OpCodes.Dup),
+                new(OpCodes.Stloc_S, ev.LocalIndex),
 
+                // Map.OnAnnouncingChaosEntrance(ev)
                 new(OpCodes.Call, Method(typeof(Handlers.Map), nameof(Handlers.Map.OnAnnouncingChaosEntrance))),
 
+                // if (!ev.IsAllowed)
+                //     builder.Clear();
+                //     return;
                 new(OpCodes.Callvirt, PropertyGetter(typeof(AnnouncingChaosEntranceEventArgs), nameof(AnnouncingChaosEntranceEventArgs.IsAllowed))),
-                new(OpCodes.Brfalse_S, returnLabel),
-            });
+                new(OpCodes.Brtrue_S, continueLabel),
 
-            newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);
+                new(OpCodes.Ldarg_1),
+                new(OpCodes.Callvirt, Method(typeof(StringBuilder), nameof(StringBuilder.Clear))),
+                new(OpCodes.Pop),
+                new(OpCodes.Ret),
+
+                new CodeInstruction(OpCodes.Nop).WithLabels(continueLabel),
+            });
 
             for (int z = 0; z < newInstructions.Count; z++)
                 yield return newInstructions[z];

--- a/EXILED/Exiled.Events/Patches/Events/Map/AnnouncingNtfEntrance.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Map/AnnouncingNtfEntrance.cs
@@ -8,6 +8,7 @@
 namespace Exiled.Events.Patches.Events.Map
 {
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Reflection.Emit;
     using System.Text.RegularExpressions;
 
@@ -26,10 +27,15 @@ namespace Exiled.Events.Patches.Events.Map
     /// Adds the <see cref="Map.AnnouncingNtfEntrance" /> event.
     /// </summary>
     [EventPatch(typeof(Map), nameof(Map.AnnouncingNtfEntrance))]
-    [HarmonyPatch(typeof(NtfWaveAnnouncement), nameof(NtfWaveAnnouncement.CreateAnnouncementString))]
-    [HarmonyPatch(typeof(NtfMiniwaveAnnouncement), nameof(NtfMiniwaveAnnouncement.CreateAnnouncementString))]
+    [HarmonyPatch]
     internal static class AnnouncingNtfEntrance
     {
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return Method(typeof(NtfWaveAnnouncement), nameof(NtfWaveAnnouncement.CreateAnnouncementString));
+            yield return Method(typeof(NtfMiniwaveAnnouncement), nameof(NtfMiniwaveAnnouncement.CreateAnnouncementString));
+        }
+
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
@@ -42,23 +48,13 @@ namespace Exiled.Events.Patches.Events.Map
             int offset = 1;
             int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Stloc_3) + offset;
 
-            // int scpsLeft = ReferenceHub.GetAllHubs().Values.Count(x => x.characterClassManager.CurRole.team == Team.SCP && x.characterClassManager.CurClass != RoleTypeId.Scp0492);
-            // string unitNameClear = Regex.Replace(unitName, "<[^>]*?>", string.Empty);
-            // string[] unitInformation = unitNameClear.Split('-');
-            //
-            // AnnouncingNtfEntranceEventArgs ev = new(scpsLeft, unitInformation[0], int.Parse(unitInformation[1]));
-            // Map.OnAnnouncingNtfEntrance(ev);
-            //
-            // if (!ev.IsAllowed)
-            //     return;
-            //
-            // unitName = $"{ev.UnitName}-{ev.UnitNumber};
-            // cassieUnitName = this.GetCassieUnitName(unitName);
-            // scpsLeft = ev.ScpsLeft;
             newInstructions.InsertRange(
                 index,
                 new CodeInstruction[]
                 {
+                    // WaveAnnouncementBase
+                    new(OpCodes.Ldarg_0),
+
                     // int scpsLeft = ReferenceHub.GetAllHubs().Values.Count(x => x.characterClassManager.CurRole.team == Team.SCP && x.characterClassManager.CurClass != RoleTypeId.Scp0492);
                     new(OpCodes.Ldloc_3),
 
@@ -86,7 +82,6 @@ namespace Exiled.Events.Patches.Events.Map
                     new(OpCodes.Ldc_I4_1),
                     new(OpCodes.Ldelem_Ref),
                     new(OpCodes.Call, Method(typeof(int), nameof(int.Parse), new[] { typeof(string) })),
-                    new(OpCodes.Ldc_I4_1),
                     new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AnnouncingNtfEntranceEventArgs))[0]),
                     new(OpCodes.Dup),
                     new(OpCodes.Dup),
@@ -98,7 +93,9 @@ namespace Exiled.Events.Patches.Events.Map
                     new(OpCodes.Callvirt, PropertyGetter(typeof(AnnouncingNtfEntranceEventArgs), nameof(AnnouncingNtfEntranceEventArgs.IsAllowed))),
                     new(OpCodes.Brfalse_S, ret),
 
-                    // unitName = $"{ev.UnitName}-{ev.UnitNumber};
+                    // lastGeneratedName = $"{ev.UnitName}-{ev.UnitNumber}";
+                    // cassie = rule.TranslateToCassie(lastGeneratedName);
+                    new(OpCodes.Ldloc_0),
                     new(OpCodes.Ldstr, "{0}-{1}"),
                     new(OpCodes.Ldloc_S, ev.LocalIndex),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(AnnouncingNtfEntranceEventArgs), nameof(AnnouncingNtfEntranceEventArgs.UnitName))),
@@ -108,9 +105,6 @@ namespace Exiled.Events.Patches.Events.Map
                     new(OpCodes.Call, Method(typeof(string), nameof(string.Format), new[] { typeof(string), typeof(object), typeof(object) })),
                     new(OpCodes.Dup),
                     new(OpCodes.Stloc_1),
-
-                    // cassieUnitName = this.TranslateToCassie(unitName);
-                    new(OpCodes.Ldloc_0),
                     new(OpCodes.Callvirt, Method(typeof(UnitNamingRule), nameof(UnitNamingRule.TranslateToCassie))),
                     new(OpCodes.Stloc_2),
 

--- a/EXILED/Exiled.Events/Patches/Events/Map/AnnouncingTeamEntrance.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Map/AnnouncingTeamEntrance.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="AnnouncingTeamEntrance.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Map
+{
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using System.Text;
+
+    using Exiled.API.Features.Pools;
+    using Exiled.Events.Attributes;
+    using Exiled.Events.EventArgs.Map;
+    using HarmonyLib;
+    using Respawning.Announcements;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Patches <see cref="WaveAnnouncementBase.PlayAnnouncement"/> to prevent cassie from playing empty string.
+    /// </summary>
+    [EventPatch(typeof(Handlers.Map), nameof(Handlers.Map.AnnouncingNtfEntrance))]
+    [EventPatch(typeof(Handlers.Map), nameof(Handlers.Map.AnnouncingChaosEntrance))]
+    [HarmonyPatch(typeof(WaveAnnouncementBase), nameof(WaveAnnouncementBase.PlayAnnouncement))]
+    internal static class AnnouncingTeamEntrance
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instruction, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instruction);
+
+            Label returnLabel = generator.DefineLabel();
+
+            int index = newInstructions.FindLastIndex(i => i.opcode == OpCodes.Ldsfld);
+
+            newInstructions.InsertRange(index, new CodeInstruction[]
+            {
+                // if (stringReturn == "")
+                //     return;
+                new(OpCodes.Ldloc_S, 4),
+                new(OpCodes.Ldstr, string.Empty),
+                new(OpCodes.Ceq),
+                new(OpCodes.Brtrue_S, returnLabel),
+            });
+
+            newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);
+
+            for (int z = 0; z < newInstructions.Count; z++)
+                yield return newInstructions[z];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+}


### PR DESCRIPTION
## Description
**Describe the changes** 
- Add `TargetMethods` to each transpiler of these events since we can't use multiple harmonypatch attribute at the same place.
- Fix `ev.IsAllowed` for the both events.
- Add a new transpiler to prevent cassie from playing if the string builder is empty.
- Other changes.

**What is the current behavior?** (You can also link to an open issue here)
- Announcing events aren't called for mini waves.
- ev.IsAllowed doesn't work.
- Some properties setter make the server crashes.
- ..

**What is the new behavior?** (if this is a feature change)
- Fix all above.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
