### PR TITLE
fix: microhid events

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Item/ChangingMicroHIDPickupStateEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Item/ChangingMicroHIDPickupStateEventArgs.cs
@@ -32,7 +32,7 @@ namespace Exiled.Events.EventArgs.Item
         /// </param>
         public ChangingMicroHIDPickupStateEventArgs(ItemPickupBase microHID, MicroHidPhase newPhase, bool isAllowed = true)
         {
-            MicroHID = (MicroHIDPickup)Pickup.Get(microHID);
+            MicroHID = Pickup.Get<MicroHIDPickup>(microHID);
             NewPhase = newPhase;
             IsAllowed = isAllowed;
         }

--- a/EXILED/Exiled.Events/EventArgs/Item/ChangingMicroHIDPickupStateEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Item/ChangingMicroHIDPickupStateEventArgs.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingMicroHIDPickupStateEventArgs.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs.Item
+{
+    using Exiled.API.Features.Pickups;
+
+    using Interfaces;
+    using InventorySystem.Items.MicroHID.Modules;
+    using InventorySystem.Items.Pickups;
+
+    /// <summary>
+    /// Contains all information before MicroHID pickup state is changed.
+    /// </summary>
+    public class ChangingMicroHIDPickupStateEventArgs : IDeniableEvent, IPickupEvent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangingMicroHIDPickupStateEventArgs" /> class.
+        /// </summary>
+        /// <param name="microHID">
+        /// <inheritdoc cref="MicroHID" />
+        /// </param>
+        /// <param name="newPhase">
+        /// <inheritdoc cref="NewPhase" />
+        /// </param>
+        /// <param name="isAllowed">
+        /// <inheritdoc cref="IsAllowed" />
+        /// </param>
+        public ChangingMicroHIDPickupStateEventArgs(ItemPickupBase microHID, MicroHidPhase newPhase, bool isAllowed = true)
+        {
+            MicroHID = (MicroHIDPickup)Pickup.Get(microHID);
+            NewPhase = newPhase;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the MicroHID instance.
+        /// </summary>
+        public MicroHIDPickup MicroHID { get; }
+
+        /// <summary>
+        /// Gets or sets the new MicroHID state.
+        /// </summary>
+        public MicroHidPhase NewPhase { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the MicroHID state can be changed.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+
+        /// <inheritdoc/>
+        public Pickup Pickup => MicroHID;
+    }
+}

--- a/EXILED/Exiled.Events/EventArgs/Player/ChangingMicroHIDStateEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/ChangingMicroHIDStateEventArgs.cs
@@ -12,6 +12,8 @@ namespace Exiled.Events.EventArgs.Player
     using API.Features;
     using API.Features.Items;
     using Interfaces;
+
+    using InventorySystem.Items;
     using InventorySystem.Items.MicroHID;
     using InventorySystem.Items.MicroHID.Modules;
 
@@ -32,9 +34,9 @@ namespace Exiled.Events.EventArgs.Player
         /// <param name="isAllowed">
         /// <inheritdoc cref="IsAllowed" />
         /// </param>
-        public ChangingMicroHIDStateEventArgs(Item microHID, MicroHidPhase newPhase, bool isAllowed = true)
+        public ChangingMicroHIDStateEventArgs(ItemBase microHID, MicroHidPhase newPhase, bool isAllowed = true)
         {
-            MicroHID = microHID.As<MicroHid>();
+            MicroHID = Item.Get<MicroHid>(microHID);
             NewPhase = newPhase;
             IsAllowed = isAllowed;
         }

--- a/EXILED/Exiled.Events/Handlers/Item.cs
+++ b/EXILED/Exiled.Events/Handlers/Item.cs
@@ -54,6 +54,11 @@ namespace Exiled.Events.Handlers
         public static Event<UsingRadioPickupBatteryEventArgs> UsingRadioPickupBattery { get; set; } = new();
 
         /// <summary>
+        /// Invoked before a<see cref="API.Features.Pickups.MicroHIDPickup"/> state is changed.
+        /// </summary>
+        public static Event<ChangingMicroHIDPickupStateEventArgs> ChangingMicroHIDPickupState { get; set; } = new();
+
+        /// <summary>
         /// Called before the ammo of an firearm is changed.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingAmmoEventArgs"/> instance.</param>
@@ -94,5 +99,11 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="UsingRadioPickupBatteryEventArgs"/> instance.</param>
         public static void OnUsingRadioPickupBattery(UsingRadioPickupBatteryEventArgs ev) => UsingRadioPickupBattery.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a <see cref="API.Features.Pickups.MicroHIDPickup"/> state is changed.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingMicroHIDPickupStateEventArgs"/> instance.</param>
+        public static void OnChangingMicroHIDPickupState(ChangingMicroHIDPickupStateEventArgs ev) => ChangingMicroHIDPickupState.InvokeSafely(ev);
     }
 }

--- a/EXILED/Exiled.Events/Patches/Events/Player/ChangingMicroHIDState.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/ChangingMicroHIDState.cs
@@ -14,6 +14,7 @@ namespace Exiled.Events.Patches.Events.Player
     using API.Features.Items;
     using API.Features.Pools;
     using Exiled.Events.Attributes;
+    using Exiled.Events.EventArgs.Item;
     using Exiled.Events.EventArgs.Player;
     using HarmonyLib;
     using InventorySystem.Items.MicroHID;
@@ -34,43 +35,43 @@ namespace Exiled.Events.Patches.Events.Player
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
 
             Label returnLabel = generator.DefineLabel();
+            Label pickupLabel = generator.DefineLabel();
+            Label continueLabel = generator.DefineLabel();
 
-            LocalBuilder ev = generator.DeclareLocal(typeof(ChangingMicroHIDStateEventArgs));
+            LocalBuilder item = generator.DeclareLocal(typeof(MicroHIDItem));
 
             int offset = 1;
             int index = newInstructions.FindIndex(x => x.opcode == OpCodes.Ret) + offset;
 
             newInstructions.InsertRange(index, new[]
             {
-                // Item.Get(this.Serial);
+                // MicroHIDItem item = Item.Get(this._prevItem);
+                // if (item is null)
+                //     pickup code;
+                // else
+                //     itemCode;
                 new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
+                new(OpCodes.Ldfld, Field(typeof(CycleController), nameof(CycleController._prevItem))),
+                new(OpCodes.Dup),
+                new(OpCodes.Stloc_S, item.LocalIndex),
+                new(OpCodes.Brfalse_S, pickupLabel),
+
+                // bool allowed = CallItemEvent(microHidItem, phase)
+                new(OpCodes.Ldloc_S, item.LocalIndex),
+                new(OpCodes.Ldarga_S, 1),
+                new(OpCodes.Call, Method(typeof(ChangingMicroHIDState), nameof(ChangingMicroHIDState.CallItemEvent))),
+
+                new CodeInstruction(OpCodes.Br_S, continueLabel),
+
+                // bool allowed = CallPickupEvent(Serial, phase)
+                new CodeInstruction(OpCodes.Ldarg_0).WithLabels(pickupLabel),
                 new(OpCodes.Ldfld, Field(typeof(CycleController), nameof(CycleController.Serial))),
-                new(OpCodes.Call, GetDeclaredMethods(typeof(Item)).Find(x => !x.IsGenericMethod && x.IsStatic && x.GetParameters().FirstOrDefault()?.ParameterType == typeof(ushort))),
+                new(OpCodes.Ldarga_S, 1),
+                new(OpCodes.Call, Method(typeof(ChangingMicroHIDState), nameof(ChangingMicroHIDState.CallPickupEvent))),
 
-                // value
-                new(OpCodes.Ldarg_1),
-
-                // true
-                new(OpCodes.Ldc_I4_1),
-
-                // ChangerMicroHIDStateEventArgs ev = new(Item.Get(this.Serial), value, true);
-                new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingMicroHIDStateEventArgs))[0]),
-                new(OpCodes.Dup),
-                new(OpCodes.Dup),
-                new(OpCodes.Stloc_S, ev.LocalIndex),
-
-                // Handlers.Player.OnChangingMicroHIDState(ev);
-                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnChangingMicroHIDState))),
-
-                // if (!ev.IsAllowed)
+                // if (!allowed)
                 //    return;
-                new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingMicroHIDStateEventArgs), nameof(ChangingMicroHIDStateEventArgs.IsAllowed))),
-                new(OpCodes.Brfalse_S, returnLabel),
-
-                // value = ev.NewPhase;
-                new(OpCodes.Ldloc_S, ev.LocalIndex),
-                new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingMicroHIDStateEventArgs), nameof(ChangingMicroHIDStateEventArgs.NewPhase))),
-                new(OpCodes.Starg_S, 1),
+                new CodeInstruction(OpCodes.Brfalse_S, returnLabel).WithLabels(continueLabel),
             });
 
             newInstructions[newInstructions.Count - 1].labels.Add(returnLabel);
@@ -79,6 +80,25 @@ namespace Exiled.Events.Patches.Events.Player
                 yield return newInstructions[z];
 
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+
+        private static bool CallItemEvent(MicroHIDItem microHIDItem, ref MicroHidPhase phase)
+        {
+            ChangingMicroHIDStateEventArgs ev = new(microHIDItem, phase);
+            Handlers.Player.OnChangingMicroHIDState(ev);
+            phase = ev.NewPhase;
+            return ev.IsAllowed;
+        }
+
+        private static bool CallPickupEvent(ushort serial, ref MicroHidPhase phase)
+        {
+            if (!MicroHIDPickup.PickupsBySerial.TryGetValue(serial, out MicroHIDPickup pickup))
+                return true;
+
+            ChangingMicroHIDPickupStateEventArgs ev = new(pickup, phase);
+            Handlers.Item.OnChangingMicroHIDPickupState(ev);
+            phase = ev.NewPhase;
+            return ev.IsAllowed;
         }
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
It turns out that microhid state changes can now happen independent from player, like when microhid is pickup
So:
- Optimized `ChangingMicroHIDStateEventArgs` to not get item by serial(and iterating all items😅).
- Added `ChangingMicroHIDPickupStateEventArgs` (in `Item` namespace)

**What is the current behavior?** (You can also link to an open issue here)
Above

**What is the new behavior?** (if this is a feature change)
Above

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No💔

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
