### PR TITLE
fix: Player.IsSpeaking and TeslaGate.IsPlayerInHurtRange

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -789,7 +789,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether the player is speaking.
         /// </summary>
-        public bool IsSpeaking => Role is Roles.IVoiceRole voiceRole && voiceRole.VoiceModule.IsSpeaking;
+        public bool IsSpeaking => Role is Roles.IVoiceRole voiceRole && voiceRole.VoiceModule.ServerIsSending;
 
         /// <summary>
         /// Gets the player's voice color.

--- a/EXILED/Exiled.API/Features/TeslaGate.cs
+++ b/EXILED/Exiled.API/Features/TeslaGate.cs
@@ -261,7 +261,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="player">The <see cref="Player"/> to check.</param>
         /// <returns><see langword="true"/> if the given <see cref="Player"/> is in the hurt range of the tesla gate; otherwise, <see langword="false"/>.</returns>
-        public bool IsPlayerInHurtRange(Player player) => player is not null && Vector3.Distance(Position, player.Position) <= Base.sizeOfTrigger * 2.2f;
+        public bool IsPlayerInHurtRange(Player player) => player is not null && Base.killers.Any(x => new Bounds(x.transform.position, Base.sizeOfKiller).Contains(player.Position));
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="Player"/> is in the idle range of a specific tesla gate.


### PR DESCRIPTION
## Description
**Describe the changes** 
*Player.IsSpeaking:* `IsSpeaking` is client-side lol. Use `ServerIsSending` instead
*TeslaGate.IsPlayerInHurtRange:* `sizeOfKiller` is size for killer `Bounds` (not a range between player and tesla gate)


**What is the current behavior?** (You can also link to an open issue here)
[VoiceChatting event results](https://cdn.discordapp.com/attachments/957552253768708096/1321508534520905811/image.png?ex=676d7e3b&is=676c2cbb&hm=727afe5881b7435a0d9926fd00a541815f46c24d209dcbfc7a2ec234e107dc2c&)


**What is the new behavior?** (if this is a feature change)
Above

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
