### PR TITLE
fix: SetFakeScale doesnt execute with currentScale

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2081,9 +2081,6 @@ namespace Exiled.API.Features
         {
             Vector3 currentScale = Scale;
 
-            if (fakeScale == currentScale)
-                return;
-
             try
             {
                 ReferenceHub.transform.localScale = fakeScale;


### PR DESCRIPTION
https://discord.com/channels/656673194693885975/1002713309876854924/1317978520701501482

## Description
**Describe the changes** 
The Player.SetFakeScale method now no longer checks if the proposed fakeScale is the current real scale of the player.


**What is the current behavior?** (You can also link to an open issue here)
The current behaviour does not allow for the fakeScale to be reset e.g.

**What is the new behavior?** (if this is a feature change)
The current behaviour does allow for the fakeScale to be reset

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing