### PR TITLE
fix: Update CustomItem.cs

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -652,7 +652,7 @@ namespace Exiled.CustomItems.API.Features
                     continue;
 
                 if (spawnPoint is LockerSpawnPoint)
-                    pickup.IsLocked = true;
+                    pickup.IsLocked = false;
 
                 if (pickup.Is(out Exiled.API.Features.Pickups.FirearmPickup firearmPickup) && this is CustomWeapon customWeapon)
                 {


### PR DESCRIPTION
set pickup.IsLocked = false; at CustomItem

## Description
**Describe the changes** 
Fix the LockerSpawnPoint that has been locked on CustomItem to make it pickable
Special Thanks to SrLicht. Thank you. Again!

**What is the current behavior?** (You can also link to an open issue here)
When CustomItem is spawned at Locker by using LockerSpawnPoint, the Item that spawned at Lockerspawnpoint will not be able to be picked up.
https://discord.com/channels/656673194693885975/1319786850549895219

**What is the new behavior?** (if this is a feature change)
Just make it pickable by unlocking it.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
