### PR TITLE
fix: LockerSpawnpoint in CustomItem

### DIFF
--- a/EXILED/Exiled.API/Features/Lockers/Locker.cs
+++ b/EXILED/Exiled.API/Features/Lockers/Locker.cs
@@ -172,7 +172,7 @@ namespace Exiled.API.Features.Lockers
             Chamber chamber = Chambers.GetRandomValue();
 
             // Determine the parent transform where the item will be placed.
-            Transform parentTransform = chamber.UseMultipleSpawnpoints && chamber.Spawnpoints.Count() > 0
+            Transform parentTransform = chamber.UseMultipleSpawnpoints && chamber.Spawnpoints.Any()
                 ? chamber.Spawnpoints.GetRandomValue()
                 : chamber.Spawnpoint;
 
@@ -180,13 +180,15 @@ namespace Exiled.API.Features.Lockers
             if (chamber.IsOpen)
             {
                 item.Transform.SetParent(parentTransform);
-                item.Spawn();
+
+                if(!item.IsSpawned)
+                    item.Spawn();
             }
             else
             {
                 // If the item is already spawned on the network, unspawn it before proceeding.
-                if (NetworkServer.spawned.ContainsKey(item.Base.netId))
-                    NetworkServer.UnSpawn(item.GameObject);
+                if (item.IsSpawned)
+                    item.UnSpawn();
 
                 // Set the item's parent transform.
                 item.Transform.SetParent(parentTransform);

--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -5,8 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Exiled.API.Features.Lockers;
-
 namespace Exiled.CustomItems.API.Features
 {
     using System;
@@ -28,10 +26,7 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.Events.EventArgs.Scp914;
     using Exiled.Loader;
 
-    using InventorySystem.Items.Firearms;
     using InventorySystem.Items.Pickups;
-
-    using MapGeneration.Distributors;
 
     using MEC;
 

--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Exiled.API.Features.Lockers;
+
 namespace Exiled.CustomItems.API.Features
 {
     using System;
@@ -651,8 +653,11 @@ namespace Exiled.CustomItems.API.Features
                 if (pickup == null)
                     continue;
 
-                if (spawnPoint is LockerSpawnPoint)
-                    pickup.IsLocked = true;
+                if (spawnPoint is LockerSpawnPoint { UseChamber: true } lockerSpawnPoint)
+                {
+                    Exiled.API.Features.Lockers.Locker? foundLocker = Exiled.API.Features.Lockers.Locker.Random(lockerSpawnPoint.Zone, lockerSpawnPoint.Type);
+                    foundLocker?.AddItem(pickup);
+                }
 
                 if (pickup.Is(out Exiled.API.Features.Pickups.FirearmPickup firearmPickup) && this is CustomWeapon customWeapon)
                 {


### PR DESCRIPTION


## Description
Fixing the brain-washing of 𝗩𝗔𝗟𝗘𝗥𝗔𝟳𝟳𝟭 in customitem
Closes #356

**What is the current behavior?** (You can also link to an open issue here)
the pickup its locked when spawning in a locker

**What is the new behavior?** (if this is a feature change)
work

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

**Other information**:
I am sleepy

Code test is in the discord bug-report.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
