### PR TITLE
fix: Exiled.API.Features.Scp914.Scp914InputObject return nothing & Exception in OnWaitingForPlayers

### DIFF
--- a/EXILED/Exiled.API/Features/Scp914.cs
+++ b/EXILED/Exiled.API/Features/Scp914.cs
@@ -77,7 +77,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating all of the GameObjects currently present inside SCP-914's intake chamber.
         /// </summary>
-        public static Collider[] InsideIntake => Physics.OverlapBox(IntakePosition, Scp914Controller.IntakeChamberSize);
+        public static Collider[] InsideIntake => Physics.OverlapBox(Scp914Controller.IntakeChamber.position, Scp914Controller.IntakeChamberSize);
 
         /// <summary>
         /// Gets the intake booth <see cref="UnityEngine.Transform"/>.
@@ -116,8 +116,7 @@ namespace Exiled.API.Features
                     {
                         pickups.Add(pickup);
                     }
-                    else if (Player.TryGet(gameObject, out Player player)
-                        && Physics.Linecast(player.Position, IntakePosition, Scp914Upgrader.SolidObjectMask))
+                    else if (Player.TryGet(gameObject, out Player player))
                     {
                         players.Add(player);
                     }

--- a/EXILED/Exiled.Events/Handlers/Internal/Round.cs
+++ b/EXILED/Exiled.Events/Handlers/Internal/Round.cs
@@ -117,7 +117,7 @@ namespace Exiled.Events.Handlers.Internal
                 if (Item.Create(firearmType.GetItemType()) is not Firearm firearm)
                     continue;
 
-                Firearm.ItemTypeToFirearmInstance.Add(firearmType, firearm);
+                Firearm.ItemTypeToFirearmInstance[firearmType] = firearm;
 
                 List<AttachmentIdentifier> attachmentIdentifiers = ListPool<AttachmentIdentifier>.Pool.Get();
                 HashSet<AttachmentSlot> attachmentsSlots = HashSetPool<AttachmentSlot>.Pool.Get();
@@ -136,8 +136,8 @@ namespace Exiled.Events.Handlers.Internal
                         .Where(attachment => attachment.Slot == slot)
                         .Min(slot => slot.Code));
 
-                Firearm.BaseCodesValue.Add(firearmType, baseCode);
-                Firearm.AvailableAttachmentsValue.Add(firearmType, attachmentIdentifiers.ToArray());
+                Firearm.BaseCodesValue[firearmType] = baseCode;
+                Firearm.AvailableAttachmentsValue[firearmType] = attachmentIdentifiers.ToArray();
 
                 ListPool<AttachmentIdentifier>.Pool.Return(attachmentIdentifiers);
                 HashSetPool<AttachmentSlot>.Pool.Return(attachmentsSlots);


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes Exiled.API.Features.Scp914.Scp914InputObject return nothing

Important: Rn function returns LightRooms (UnityEngine.GameObject) inside HashSet<GameObject> inside914. idk if it should. but list of players and pickups is correct, there is just 1 addtional gameobject in array function is returning. Like this:
[tst] 4 2 1
[tst] LightRooms (UnityEngine.GameObject)
[tst] Player(Clone) (UnityEngine.GameObject)
[tst] Player(Clone) (UnityEngine.GameObject)
[tst] FirearmPickup(Clone) (UnityEngine.GameObject)
first number - total array size, second number - players array size, third - pickups array size. logged total array

Fixes Exception in OnWaitingForPlayers

**What is the current behavior?** (You can also link to an open issue here)
returns nothing,
gives exception

**What is the new behavior?** (if this is a feature change)
returns what it should,
no exception

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
Just a fix
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [?] Still requires more testing
