### PR TITLE
fix: "OnDroppedAmmo" event does not trigger

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/DroppingAmmo.cs
@@ -95,9 +95,9 @@ namespace Exiled.Events.Patches.Events.Player
                 // ammoPickups
                 new(OpCodes.Ldloc_S, ammoPickups.LocalIndex),
 
-                // Handlers::Player::OnDroppedItem(new DroppedAmmoEventArgs(ev.Player, ev.AmmoType, ev.Amount, ammoPickups))
+                // Handlers::Player::OnDroppedAmmo(new DroppedAmmoEventArgs(ev.Player, ev.AmmoType, ev.Amount, ammoPickups))
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(DroppedAmmoEventArgs))[0]),
-                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnDroppedItem))),
+                new(OpCodes.Call, Method(typeof(Handlers.Player), nameof(Handlers.Player.OnDroppedAmmo))),
             });
 
             newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);


### PR DESCRIPTION
## Description
**Describe the changes** 
Updated the invoke method from `OnDroppedItem` to `OnDroppedAmmo`in the DroppingAmmo patch.

**What is the current behavior?** (You can also link to an open issue here)
invoke `OnDroppedItem`

**What is the new behavior?** (if this is a feature change)
invoke `OnDroppedAmmo`.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
`DropAmmo `will no longer invoke `DroppedItem`

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [may] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
