### PR TITLE
fix: setting base deleting all other settings

### DIFF
--- a/EXILED/Exiled.API/Features/Core/UserSettings/SettingBase.cs
+++ b/EXILED/Exiled.API/Features/Core/UserSettings/SettingBase.cs
@@ -225,21 +225,20 @@ namespace Exiled.API.Features.Core.UserSettings
         /// <remarks>This method is used to sync new settings with players.</remarks>
         public static IEnumerable<SettingBase> Register(IEnumerable<SettingBase> settings, Func<Player, bool> predicate = null)
         {
-            IList<SettingBase> list = settings as IList<SettingBase> ?? settings.ToArray();
+            IEnumerable<IGrouping<HeaderSetting, SettingBase>> grouped = settings.Where(s => s != null).GroupBy(s => s.Header);
 
             List<SettingBase> result = new();
-            result.AddRange(list.Where(x => x.Header == null));
-
-            IEnumerable<IGrouping<HeaderSetting, SettingBase>> grouped = list.Where(s => s != null && s.Header != null).GroupBy(s => s.Header);
 
             // Group settings by headers
             foreach (IGrouping<HeaderSetting, SettingBase> grouping in grouped)
             {
-                result.Add(grouping.Key);
+                if (grouping.Key != null)
+                    result.Add(grouping.Key);
+
                 result.AddRange(grouping);
             }
 
-            ServerSpecificSettingsSync.DefinedSettings = result.Select(s => s.Base).ToArray();
+            ServerSpecificSettingsSync.DefinedSettings = (ServerSpecificSettingsSync.DefinedSettings ?? Array.Empty<ServerSpecificSettingBase>()).Concat(result.Select(s => s.Base)).ToArray();
             Settings.AddRange(result);
 
             if (predicate == null)


### PR DESCRIPTION
## Description
Stops settingbase from deleting all other settings on register


**What is the current behavior?** (You can also link to an open issue here)
Deletes all settings except the last one registered

**What is the new behavior?** (if this is a feature change)
Keeps all settings

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
