### PR TITLE
feat(Speaker): add transform create

### DIFF
--- a/EXILED/Exiled.API/Features/Toys/Speaker.cs
+++ b/EXILED/Exiled.API/Features/Toys/Speaker.cs
@@ -123,6 +123,28 @@ namespace Exiled.API.Features.Toys
         }
 
         /// <summary>
+        /// Creates a new <see cref="Speaker"/>.
+        /// </summary>
+        /// <param name="transform">The transform to create this <see cref="Speaker"/> on.</param>
+        /// <param name="spawn">Whether the <see cref="Speaker"/> should be initially spawned.</param>
+        /// <param name="worldPositionStays">Whether the <see cref="Speaker"/> should keep the same world position.</param>
+        /// <returns>The new <see cref="Speaker"/>.</returns>
+        public static Speaker Create(Transform transform, bool spawn, bool worldPositionStays = true)
+        {
+            Speaker speaker = new(Object.Instantiate(Prefab, transform, worldPositionStays))
+            {
+                Position = transform.position,
+                Rotation = transform.rotation,
+                Scale = transform.localScale.normalized,
+            };
+
+            if(spawn)
+                speaker.Spawn();
+
+            return speaker;
+        }
+
+        /// <summary>
         /// Plays audio through this speaker.
         /// </summary>
         /// <param name="message">An <see cref="AudioMessage"/> instance.</param>


### PR DESCRIPTION
## Description
Adds a new Speaker instantiate method that allows you to bind with a transform


**What is the current behavior?** (You can also link to an open issue here)
Right now, you can only spawn based on a position, not a transform, so you can't stick it to the transform.

**What is the new behavior?** (if this is a feature change)
Allows you to create a Speaker based on a transform

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
