### PR TITLE
fix: Potential Error Fix With Custom Weapon Reloading

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -237,7 +237,13 @@ namespace Exiled.CustomItems.API.Features
                 int firearmAmmo = ev.Firearm.MagazineAmmo;
                 int ammoDrop = -(ClipSize - firearmAmmo - ammoChambered);
 
-                int ammoInInventory = ev.Player.Ammo[ammoType.GetItemType()] + firearmAmmo;
+                ushort playerAmmo = 0;
+                if (ev.Player.Ammo.TryGetValue(ammoType.GetItemType(), out ushort ammo))
+                {
+                    playerAmmo = ammo;
+                }
+
+                int ammoInInventory = playerAmmo + firearmAmmo;
                 if (ammoToGive < ammoInInventory)
                 {
                     ev.Firearm.MagazineAmmo = ammoToGive;

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -237,13 +237,7 @@ namespace Exiled.CustomItems.API.Features
                 int firearmAmmo = ev.Firearm.MagazineAmmo;
                 int ammoDrop = -(ClipSize - firearmAmmo - ammoChambered);
 
-                ushort playerAmmo = 0;
-                if (ev.Player.Ammo.TryGetValue(ammoType.GetItemType(), out ushort ammo))
-                {
-                    playerAmmo = ammo;
-                }
-
-                int ammoInInventory = playerAmmo + firearmAmmo;
+                int ammoInInventory = ev.Player.GetAmmo(ammoType) + firearmAmmo;
                 if (ammoToGive < ammoInInventory)
                 {
                     ev.Firearm.MagazineAmmo = ammoToGive;


### PR DESCRIPTION
## Description
**Describe the changes** 
- Added a check to try get value from the dictionary instead of accessing it for how much ammo is in player inventory.

**What is the current behavior?** (You can also link to an open issue here)
- Accesses the dictionary directly which could cause an error since this event runs after the ammo is loaded into the gun.

**What is the new behavior?** (if this is a feature change)
- Uses a try get value to get the ammo if it cant find it defaults to 0.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
N/A

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
