### PR TITLE
fix: Player Custom Firearm Reloading Exploit

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -225,7 +225,7 @@ namespace Exiled.CustomItems.API.Features
 
         private void OnInternalReloaded(ReloadedWeaponEventArgs ev)
         {
-            if (!Check(ev.Player.CurrentItem))
+            if (!Check(ev.Item))
                 return;
 
             if (ClipSize > 0)

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -225,7 +225,7 @@ namespace Exiled.CustomItems.API.Features
 
         private void OnInternalReloaded(ReloadedWeaponEventArgs ev)
         {
-            if (!Check(ev.Item))
+            if (!Check(ev.Item) || ev.Player.CurrentItem != ev.Item)
                 return;
 
             if (ClipSize > 0)

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -225,7 +225,7 @@ namespace Exiled.CustomItems.API.Features
 
         private void OnInternalReloaded(ReloadedWeaponEventArgs ev)
         {
-            if (!Check(ev.Item) || ev.Player.CurrentItem != ev.Item)
+            if (!Check(ev.Item))
                 return;
 
             if (ClipSize > 0)


### PR DESCRIPTION
## Description
**Describe the changes** 
- Fixed players being able to exploit custom items to not get the intended clipsize amount by switching off the weapon quickly after reloading. 

**What is the current behavior?** (You can also link to an open issue here)
- Player can exploit by switching off weapon quickly after reloading. 

**What is the new behavior?** (if this is a feature change)
- Player can't exploit. 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
N/A

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
