### PR TITLE
Add priority for event handlers to Exiled Events

### DIFF
--- a/EXILED/Exiled.Events/Features/Event.cs
+++ b/EXILED/Exiled.Events/Features/Event.cs
@@ -14,6 +14,7 @@ namespace Exiled.Events.Features
     using Exiled.API.Features;
     using Exiled.Events.EventArgs.Interfaces;
     using MEC;
+    using PluginAPI.Roles;
 
     /// <summary>
     /// The custom <see cref="EventHandler"/> delegate, with empty parameters.
@@ -31,7 +32,19 @@ namespace Exiled.Events.Features
     /// </summary>
     public class Event : IExiledEvent
     {
+        private record Registration(CustomEventHandler handler, int priority);
+
+        private record AsyncRegistration(CustomAsyncEventHandler handler, int priority);
+
         private static readonly List<Event> EventsValue = new();
+
+        private static readonly IComparer<Registration> RegisterComparable = Comparer<Registration>.Create((x, y) => y.priority - x.priority);
+
+        private static readonly IComparer<AsyncRegistration> AsyncRegisterComparable = Comparer<AsyncRegistration>.Create((x, y) => y.priority - x.priority);
+
+        private readonly List<Registration> innerEvent = new();
+
+        private readonly List<AsyncRegistration> innerAsyncEvent = new();
 
         private bool patched;
 
@@ -42,10 +55,6 @@ namespace Exiled.Events.Features
         {
             EventsValue.Add(this);
         }
-
-        private event CustomEventHandler InnerEvent;
-
-        private event CustomAsyncEventHandler InnerAsyncEvent;
 
         /// <summary>
         /// Gets a <see cref="IReadOnlyList{T}"/> of <see cref="Event{T}"/> which contains all the <see cref="Event{T}"/> instances.
@@ -105,6 +114,16 @@ namespace Exiled.Events.Features
         /// </summary>
         /// <param name="handler">The handler to add.</param>
         public void Subscribe(CustomEventHandler handler)
+            => Subscribe(handler, 0);
+
+        // I try to do inheritated summary but the analizer refuse
+
+        /// <summary>
+        /// Subscribes a target <see cref="CustomEventHandler"/> to the inner event if the conditional is true.
+        /// </summary>
+        /// <param name="handler">The handler to add.</param>
+        /// <param name="priority">The highest priority is the first called, the lowest the last.</param>
+        public void Subscribe(CustomEventHandler handler, int priority)
         {
             Log.Assert(Events.Instance is not null, $"{nameof(Events.Instance)} is null, please ensure you have exiled_events enabled!");
 
@@ -114,7 +133,18 @@ namespace Exiled.Events.Features
                 patched = true;
             }
 
-            InnerEvent += handler;
+            Registration registration = new Registration(handler, priority);
+            int index = innerEvent.BinarySearch(registration, RegisterComparable);
+            if (index < 0)
+            {
+                innerEvent.Insert(~index, registration);
+            }
+            else
+            {
+                while (index < innerEvent.Count && innerEvent[index].priority == priority)
+                    index++;
+                innerEvent.Insert(index, registration);
+            }
         }
 
         /// <summary>
@@ -122,6 +152,14 @@ namespace Exiled.Events.Features
         /// </summary>
         /// <param name="handler">The handler to add.</param>
         public void Subscribe(CustomAsyncEventHandler handler)
+            => Subscribe(handler, 0);
+
+        /// <summary>
+        /// Subscribes a target <see cref="CustomAsyncEventHandler"/> to the inner event if the conditional is true.
+        /// </summary>
+        /// <param name="handler">The handler to add.</param>
+        /// <param name="priority">The highest priority is the first called, the lowest the last.</param>
+        public void Subscribe(CustomAsyncEventHandler handler, int priority)
         {
             Log.Assert(Events.Instance is not null, $"{nameof(Events.Instance)} is null, please ensure you have exiled_events enabled!");
 
@@ -131,7 +169,18 @@ namespace Exiled.Events.Features
                 patched = true;
             }
 
-            InnerAsyncEvent += handler;
+            AsyncRegistration registration = new AsyncRegistration(handler, 0);
+            int index = innerAsyncEvent.BinarySearch(registration, AsyncRegisterComparable);
+            if (index < 0)
+            {
+                innerAsyncEvent.Insert(~index, registration);
+            }
+            else
+            {
+                while (index < innerAsyncEvent.Count && innerAsyncEvent[index].priority == priority)
+                    index++;
+                innerAsyncEvent.Insert(index, registration);
+            }
         }
 
         /// <summary>
@@ -140,7 +189,9 @@ namespace Exiled.Events.Features
         /// <param name="handler">The handler to add.</param>
         public void Unsubscribe(CustomEventHandler handler)
         {
-            InnerEvent -= handler;
+            int index = innerEvent.FindIndex(p => p.handler == handler);
+            if (index != -1)
+                innerEvent.RemoveAt(index);
         }
 
         /// <summary>
@@ -149,7 +200,9 @@ namespace Exiled.Events.Features
         /// <param name="handler">The handler to add.</param>
         public void Unsubscribe(CustomAsyncEventHandler handler)
         {
-            InnerAsyncEvent -= handler;
+            int index = innerAsyncEvent.FindIndex(p => p.handler == handler);
+            if (index != -1)
+                innerAsyncEvent.RemoveAt(index);
         }
 
         /// <summary>
@@ -157,25 +210,61 @@ namespace Exiled.Events.Features
         /// </summary>
         public void InvokeSafely()
         {
-            InvokeNormal();
-            InvokeAsync();
+            BlendedInvoke();
+
+            // InvokeNormal();
+            // InvokeAsync();
+        }
+
+        /// <inheritdoc cref="InvokeSafely"/>
+        internal void BlendedInvoke()
+        {
+            int count = innerEvent.Count + innerAsyncEvent.Count;
+            int eventIndex = 0, asyncEventIndex = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                if (eventIndex < innerEvent.Count && (asyncEventIndex >= innerAsyncEvent.Count || innerEvent[eventIndex].priority >= innerAsyncEvent[asyncEventIndex].priority))
+                {
+                    try
+                    {
+                        innerEvent[eventIndex].handler();
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Method \"{innerEvent[eventIndex].handler.Method.Name}\" of the class \"{innerEvent[eventIndex].handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    }
+
+                    eventIndex++;
+                }
+                else
+                {
+                    try
+                    {
+                        Timing.RunCoroutine(innerAsyncEvent[asyncEventIndex].handler());
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Method \"{innerAsyncEvent[asyncEventIndex].handler.Method.Name}\" of the class \"{innerAsyncEvent[asyncEventIndex].handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    }
+
+                    asyncEventIndex++;
+                }
+            }
         }
 
         /// <inheritdoc cref="InvokeSafely"/>
         internal void InvokeNormal()
         {
-            if (InnerEvent is null)
-                return;
-
-            foreach (CustomEventHandler handler in InnerEvent.GetInvocationList().Cast<CustomEventHandler>())
+            foreach (Registration registration in innerEvent)
             {
                 try
                 {
-                    handler();
+                    registration.handler();
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Method \"{handler.Method.Name}\" of the class \"{handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    Log.Error($"Method \"{registration.handler.Method.Name}\" of the class \"{registration.handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
                 }
             }
         }
@@ -183,18 +272,15 @@ namespace Exiled.Events.Features
         /// <inheritdoc cref="InvokeSafely"/>
         internal void InvokeAsync()
         {
-            if (InnerAsyncEvent is null)
-                return;
-
-            foreach (CustomAsyncEventHandler handler in InnerAsyncEvent.GetInvocationList().Cast<CustomAsyncEventHandler>())
+            foreach (AsyncRegistration registration in innerAsyncEvent)
             {
                 try
                 {
-                    Timing.RunCoroutine(handler());
+                    Timing.RunCoroutine(registration.handler());
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Method \"{handler.Method.Name}\" of the class \"{handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    Log.Error($"Method \"{registration.handler.Method.Name}\" of the class \"{registration.handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
                 }
             }
         }

--- a/EXILED/Exiled.Events/Features/Event{T}.cs
+++ b/EXILED/Exiled.Events/Features/Event{T}.cs
@@ -36,7 +36,19 @@ namespace Exiled.Events.Features
     /// <typeparam name="T">The specified <see cref="EventArgs"/> that the event will use.</typeparam>
     public class Event<T> : IExiledEvent
     {
+        private record Registration(CustomEventHandler<T> handler, int priority);
+
+        private record AsyncRegistration(CustomAsyncEventHandler<T> handler, int priority);
+
         private static readonly Dictionary<Type, Event<T>> TypeToEvent = new();
+
+        private static readonly IComparer<Registration> RegisterComparable = Comparer<Registration>.Create((x, y) => y.priority - x.priority);
+
+        private static readonly IComparer<AsyncRegistration> AsyncRegisterComparable = Comparer<AsyncRegistration>.Create((x, y) => y.priority - x.priority);
+
+        private readonly List<Registration> innerEvent = new();
+
+        private readonly List<AsyncRegistration> innerAsyncEvent = new();
 
         private bool patched;
 
@@ -47,10 +59,6 @@ namespace Exiled.Events.Features
         {
             TypeToEvent.Add(typeof(T), this);
         }
-
-        private event CustomEventHandler<T> InnerEvent;
-
-        private event CustomAsyncEventHandler<T> InnerAsyncEvent;
 
         /// <summary>
         /// Gets a <see cref="IReadOnlyCollection{T}"/> of <see cref="Event{T}"/> which contains all the <see cref="Event{T}"/> instances.
@@ -110,6 +118,14 @@ namespace Exiled.Events.Features
         /// </summary>
         /// <param name="handler">The handler to add.</param>
         public void Subscribe(CustomEventHandler<T> handler)
+            => Subscribe(handler, 0);
+
+        /// <summary>
+        /// Subscribes a target <see cref="CustomEventHandler{T}"/> to the inner event if the conditional is true.
+        /// </summary>
+        /// <param name="handler">The handler to add.</param>
+        /// <param name="priority">The highest priority is the first called, the lowest the last.</param>
+        public void Subscribe(CustomEventHandler<T> handler, int priority)
         {
             Log.Assert(Events.Instance is not null, $"{nameof(Events.Instance)} is null, please ensure you have exiled_events enabled!");
 
@@ -119,7 +135,18 @@ namespace Exiled.Events.Features
                 patched = true;
             }
 
-            InnerEvent += handler;
+            Registration registration = new Registration(handler, priority);
+            int index = innerEvent.BinarySearch(registration, RegisterComparable);
+            if (index < 0)
+            {
+                innerEvent.Insert(~index, registration);
+            }
+            else
+            {
+                while (index < innerEvent.Count && innerEvent[index].priority == priority)
+                    index++;
+                innerEvent.Insert(index, registration);
+            }
         }
 
         /// <summary>
@@ -127,6 +154,14 @@ namespace Exiled.Events.Features
         /// </summary>
         /// <param name="handler">The handler to add.</param>
         public void Subscribe(CustomAsyncEventHandler<T> handler)
+            => Subscribe(handler, 0);
+
+        /// <summary>
+        /// Subscribes a target <see cref="CustomAsyncEventHandler{T}"/> to the inner event if the conditional is true.
+        /// </summary>
+        /// <param name="handler">The handler to add.</param>
+        /// <param name="priority">The highest priority is the first called, the lowest the last.</param>
+        public void Subscribe(CustomAsyncEventHandler<T> handler, int priority)
         {
             Log.Assert(Events.Instance is not null, $"{nameof(Events.Instance)} is null, please ensure you have exiled_events enabled!");
 
@@ -136,7 +171,18 @@ namespace Exiled.Events.Features
                 patched = true;
             }
 
-            InnerAsyncEvent += handler;
+            AsyncRegistration registration = new AsyncRegistration(handler, 0);
+            int index = innerAsyncEvent.BinarySearch(registration, AsyncRegisterComparable);
+            if (index < 0)
+            {
+                innerAsyncEvent.Insert(~index, registration);
+            }
+            else
+            {
+                while (index < innerAsyncEvent.Count && innerAsyncEvent[index].priority == priority)
+                    index++;
+                innerAsyncEvent.Insert(index, registration);
+            }
         }
 
         /// <summary>
@@ -145,7 +191,9 @@ namespace Exiled.Events.Features
         /// <param name="handler">The handler to add.</param>
         public void Unsubscribe(CustomEventHandler<T> handler)
         {
-            InnerEvent -= handler;
+            int index = innerEvent.FindIndex(p => p.handler == handler);
+            if (index != -1)
+                innerEvent.RemoveAt(index);
         }
 
         /// <summary>
@@ -154,7 +202,9 @@ namespace Exiled.Events.Features
         /// <param name="handler">The handler to add.</param>
         public void Unsubscribe(CustomAsyncEventHandler<T> handler)
         {
-            InnerAsyncEvent -= handler;
+            int index = innerAsyncEvent.FindIndex(p => p.handler == handler);
+            if (index != -1)
+                innerAsyncEvent.RemoveAt(index);
         }
 
         /// <summary>
@@ -164,25 +214,61 @@ namespace Exiled.Events.Features
         /// <exception cref="ArgumentNullException">Event or its arg is <see langword="null"/>.</exception>
         public void InvokeSafely(T arg)
         {
-            InvokeNormal(arg);
-            InvokeAsync(arg);
+            BlendedInvoke(arg);
+
+            // InvokeNormal(arg);
+            // InvokeAsync(arg);
+        }
+
+        /// <inheritdoc cref="InvokeSafely"/>
+        internal void BlendedInvoke(T arg)
+        {
+            int count = innerEvent.Count + innerAsyncEvent.Count;
+            int eventIndex = 0, asyncEventIndex = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                if (eventIndex < innerEvent.Count && (asyncEventIndex >= innerAsyncEvent.Count || innerEvent[eventIndex].priority >= innerAsyncEvent[asyncEventIndex].priority))
+                {
+                    try
+                    {
+                        innerEvent[eventIndex].handler(arg);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Method \"{innerEvent[eventIndex].handler.Method.Name}\" of the class \"{innerEvent[eventIndex].handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    }
+
+                    eventIndex++;
+                }
+                else
+                {
+                    try
+                    {
+                        Timing.RunCoroutine(innerAsyncEvent[asyncEventIndex].handler(arg));
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Method \"{innerAsyncEvent[asyncEventIndex].handler.Method.Name}\" of the class \"{innerAsyncEvent[asyncEventIndex].handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    }
+
+                    asyncEventIndex++;
+                }
+            }
         }
 
         /// <inheritdoc cref="InvokeSafely"/>
         internal void InvokeNormal(T arg)
         {
-            if (InnerEvent is null)
-                return;
-
-            foreach (CustomEventHandler<T> handler in InnerEvent.GetInvocationList().Cast<CustomEventHandler<T>>())
+            foreach (Registration registration in innerEvent)
             {
                 try
                 {
-                    handler(arg);
+                    registration.handler(arg);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Method \"{handler.Method.Name}\" of the class \"{handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    Log.Error($"Method \"{registration.handler.Method.Name}\" of the class \"{registration.handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
                 }
             }
         }
@@ -190,18 +276,15 @@ namespace Exiled.Events.Features
         /// <inheritdoc cref="InvokeSafely"/>
         internal void InvokeAsync(T arg)
         {
-            if (InnerAsyncEvent is null)
-                return;
-
-            foreach (CustomAsyncEventHandler<T> handler in InnerAsyncEvent.GetInvocationList().Cast<CustomAsyncEventHandler<T>>())
+            foreach (AsyncRegistration registration in innerAsyncEvent)
             {
                 try
                 {
-                    Timing.RunCoroutine(handler(arg));
+                    Timing.RunCoroutine(registration.handler(arg));
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Method \"{handler.Method.Name}\" of the class \"{handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
+                    Log.Error($"Method \"{registration.handler.Method.Name}\" of the class \"{registration.handler.Method.ReflectedType.FullName}\" caused an exception when handling the event \"{GetType().FullName}\"\n{ex}");
                 }
             }
         }


### PR DESCRIPTION
## Description
**Describe the changes** 
Add priority for the eventhandler to the exiled events. This allows the plugin to be the last to handle an event even if the plugin has a high priority and vice versa.

**What is the current behavior?** (You can also link to an open issue here)
The current behaviour follow the order of ellements added in the inner event. First added first called.
First call the "classic" handler then coroutine handler.

**What is the new behavior?** (if this is a feature change)
First added first called, when same priority. highest priority, first call.
First call the "classic" handler then coroutine handler, when same priority.

**Does this PR introduce a breaking change?** no

**Other information**: I like trains
I didn't test it in game only in unit tests.
I don't care if this pull request get merge or not it's just a draft.
It took me 10 minutes to code it.

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
