### PR TITLE
feat: added GameObject and Transform properties to AdminToy

### DIFF
--- a/EXILED/Exiled.API/Features/Toys/AdminToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/AdminToy.cs
@@ -116,12 +116,12 @@ namespace Exiled.API.Features.Toys
         }
 
         /// <summary>
-        /// Gets the <see cref="GameObject"/> of the toy.
+        /// Gets the <see cref="UnityEngine.GameObject"/> of the toy.
         /// </summary>
         public GameObject GameObject => AdminToyBase.gameObject;
 
         /// <summary>
-        /// Gets the <see cref="Transform"/> of the toy.
+        /// Gets the <see cref="UnityEngine.Transform"/> of the toy.
         /// </summary>
         public Transform Transform => AdminToyBase.transform;
 

--- a/EXILED/Exiled.API/Features/Toys/AdminToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/AdminToy.cs
@@ -116,6 +116,16 @@ namespace Exiled.API.Features.Toys
         }
 
         /// <summary>
+        /// Gets the <see cref="GameObject"/> of the toy.
+        /// </summary>
+        public GameObject GameObject => AdminToyBase.gameObject;
+
+        /// <summary>
+        /// Gets the <see cref="Transform"/> of the toy.
+        /// </summary>
+        public Transform Transform => AdminToyBase.transform;
+
+        /// <summary>
         /// Gets or sets the movement smoothing value of the toy.
         /// <para>
         /// Higher values reflect smoother movements.

--- a/EXILED/Exiled.API/Features/Toys/ShootingTargetToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/ShootingTargetToy.cs
@@ -66,6 +66,9 @@ namespace Exiled.API.Features.Toys
         /// </summary>
         public ShootingTarget Base { get; }
 
+        /// <inheritdoc cref="AdminToy.GameObject"/>
+        public new GameObject GameObject => base.GameObject;
+
         /// <summary>
         /// Gets the <see cref="UnityEngine.GameObject"/> of the bullseye.
         /// </summary>

--- a/EXILED/Exiled.API/Features/Toys/ShootingTargetToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/ShootingTargetToy.cs
@@ -67,11 +67,6 @@ namespace Exiled.API.Features.Toys
         public ShootingTarget Base { get; }
 
         /// <summary>
-        /// Gets the <see cref="UnityEngine.GameObject"/> of the target.
-        /// </summary>
-        public GameObject GameObject => Base.gameObject;
-
-        /// <summary>
         /// Gets the <see cref="UnityEngine.GameObject"/> of the bullseye.
         /// </summary>
         public GameObject Bullseye => Base._bullsEye.gameObject;


### PR DESCRIPTION
## Description
**Describe the changes**
Added GameObject and Transform properties to AdminToy for convinience

**What is the current behavior?** (You can also link to an open issue here)
Transform and GameObject have to be accesses through .Base (e.g. primitive.Base.transform)

**What is the new behavior?** (if this is a feature change)
Transform and GameObject can be accessed directly through Exiled AdminToys

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Other
- [ ] Still requires more testing
