### PR TITLE
feat: send to player specific settings

### DIFF
--- a/EXILED/Exiled.API/Features/Core/UserSettings/SettingBase.cs
+++ b/EXILED/Exiled.API/Features/Core/UserSettings/SettingBase.cs
@@ -217,6 +217,14 @@ namespace Exiled.API.Features.Core.UserSettings
         public static void SendToPlayer(Player player) => ServerSpecificSettingsSync.SendToPlayer(player.ReferenceHub);
 
         /// <summary>
+        /// Syncs specific settings with the specified target.
+        /// </summary>
+        /// <param name="player">Target player.</param>
+        /// <param name="settings">Settings to send to the player.</param>
+        public static void SendToPlayer(Player player, IEnumerable<SettingBase> settings) =>
+            ServerSpecificSettingsSync.SendToPlayer(player.ReferenceHub, settings.Select(setting => setting.Base).ToArray());
+
+        /// <summary>
         /// Registers all settings from the specified collection.
         /// </summary>
         /// <param name="settings">A collection of settings to register.</param>


### PR DESCRIPTION
## Description
Adds a function to send specific settings to a specific player. This could be useful when you want to send settings depending on an event that gets triggered. I.e. supporter only benefits that you check via group, which isn't set during the OnVerified event.

**What is the current behavior?** (You can also link to an open issue here)
Can't send specific settings to specific players, have to use SendToAll and that could break in very specific cases.

<br />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
