### PR TITLE
feat: Added ICommandSender to Kicking/Banning EventArgs

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Player/BanningEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/BanningEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs.Player
     using System.Reflection;
 
     using API.Features;
+    using CommandSystem;
 
     /// <summary>
     /// Contains all information before banning a player from the server.
@@ -23,12 +24,13 @@ namespace Exiled.Events.EventArgs.Player
         /// </summary>
         /// <param name="target">The ban target.</param>
         /// <param name="issuer">The ban issuer.</param>
+        /// <param name="commandSender">The ban command sender.</param>
         /// <param name="duration">The ban seconds duration.</param>
         /// <param name="reason">The ban reason.</param>
         /// <param name="fullMessage">The ban full message.</param>
         /// <param name="isAllowed">Indicates whether the event can be executed or not.</param>
-        public BanningEventArgs(Player target, Player issuer, long duration, string reason, string fullMessage, bool isAllowed = true)
-            : base(target, issuer, reason, fullMessage, isAllowed)
+        public BanningEventArgs(Player target, Player issuer, ICommandSender commandSender, long duration, string reason, string fullMessage, bool isAllowed = true)
+            : base(target, issuer, commandSender, reason, fullMessage, isAllowed)
         {
             Duration = duration;
         }

--- a/EXILED/Exiled.Events/EventArgs/Player/KickingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/KickingEventArgs.cs
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs.Player
     using System.Reflection;
 
     using API.Features;
-
+    using CommandSystem;
     using Interfaces;
 
     /// <summary>
@@ -32,6 +32,9 @@ namespace Exiled.Events.EventArgs.Player
         /// <param name="issuer">
         /// <inheritdoc cref="Player" />
         /// </param>
+        /// <param name="commandSender">
+        /// <inheritdoc cref="ICommandSender" />
+        /// </param>
         /// <param name="reason">
         /// <inheritdoc cref="Reason" />
         /// </param>
@@ -41,10 +44,11 @@ namespace Exiled.Events.EventArgs.Player
         /// <param name="isAllowed">
         /// <inheritdoc cref="IsAllowed" />
         /// </param>
-        public KickingEventArgs(Player target, Player issuer, string reason, string fullMessage, bool isAllowed = true)
+        public KickingEventArgs(Player target, Player issuer, ICommandSender commandSender, string reason, string fullMessage, bool isAllowed = true)
         {
             Target = target;
             Player = issuer ?? Server.Host;
+            CommandSender = commandSender;
             Reason = reason;
             startkickmessage = fullMessage;
             IsAllowed = isAllowed;
@@ -113,6 +117,11 @@ namespace Exiled.Events.EventArgs.Player
                 issuer = value;
             }
         }
+
+        /// <summary>
+        /// Gets the command sender.
+        /// </summary>
+        public ICommandSender CommandSender { get; }
 
         /// <summary>
         /// Logs the kick, anti-backdoor protection from malicious plugins.

--- a/EXILED/Exiled.Events/Patches/Events/Player/Banning.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/Banning.cs
@@ -46,16 +46,24 @@ namespace Exiled.Events.Patches.Events.Player
                 index,
                 new[]
                 {
+                    // target
                     new(OpCodes.Ldarg_0),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(Footprint) })),
 
+                    // issuer
                     new(OpCodes.Ldarg_1),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ICommandSender) })),
 
+                    // commandSender
+                    new(OpCodes.Ldarg_1),
+
+                    // duration
                     new(OpCodes.Ldarg_3),
 
+                    // reason
                     new(OpCodes.Ldarg_2),
 
+                    // fullMessage
                     new(OpCodes.Ldstr, "You have been banned. "),
                     new(OpCodes.Ldarg_2),
                     new(OpCodes.Call, Method(typeof(string), nameof(string.IsNullOrEmpty))),
@@ -67,8 +75,10 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Call, Method(typeof(string), nameof(string.Concat), new[] { typeof(string), typeof(string) })),
                     new CodeInstruction(OpCodes.Call, Method(typeof(string), nameof(string.Concat), new[] { typeof(string), typeof(string) })).WithLabels(empty),
 
+                    // isAllowed = true
                     new(OpCodes.Ldc_I4_1),
 
+                    // ev = new BanningEventArgs(target, issuer, commandSender, duration, reason, fullMessage, true)
                     new(OpCodes.Newobj, GetDeclaredConstructors(typeof(BanningEventArgs))[0]),
                     new(OpCodes.Dup),
                     new(OpCodes.Dup),

--- a/EXILED/Exiled.Events/Patches/Events/Player/Kicking.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/Kicking.cs
@@ -49,6 +49,9 @@ namespace Exiled.Events.Patches.Events.Player
                 new(OpCodes.Ldarg_1),
                 new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ICommandSender) })),
 
+                // commandSender
+                new(OpCodes.Ldarg_1),
+
                 // reason
                 new(OpCodes.Ldarg_2),
 
@@ -58,7 +61,7 @@ namespace Exiled.Events.Patches.Events.Player
                 // true
                 new(OpCodes.Ldc_I4_1),
 
-                // KickingEventArgs ev = new(Player, Player, string, string, bool)
+                // KickingEventArgs ev = new(Player, Player, ICommandSender, string, string, bool)
                 new(OpCodes.Newobj, GetDeclaredConstructors(typeof(KickingEventArgs))[0]),
                 new(OpCodes.Dup),
                 new(OpCodes.Dup),


### PR DESCRIPTION
## Description
**Describe the changes**
This pull request adds ICommandSender to Kicking and Banning EventArgs. This might be useful when devs make a custom CommandSender class that contains extra data (e.g. DiscordCommandSender), but currently it just gets turned into Server.Host in the events.

**What is the current behavior?** (You can also link to an open issue here)
😭

**What is the new behavior?** (if this is a feature change)
😊

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It does not

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [X] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
