### PR TITLE
fix: IntercomSpeaking event

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
@@ -38,15 +38,14 @@ namespace Exiled.Events.Patches.Events.Player
             Label returnLabel = generator.DefineLabel();
 
             const int offset = -2;
-            int index = newInstructions.FindIndex(instruction => instruction.Calls(Method(typeof(Stopwatch), nameof(Stopwatch.Restart)))) + offset;
+            int index = newInstructions.FindIndex(instruction => instruction.StoresField(Field(typeof(Intercom), nameof(Intercom._curSpeaker))))) + offset;
 
             newInstructions.InsertRange(
                 index,
                 new CodeInstruction[]
                 {
-                    // Player.Get(this._curSpeaker)
-                    new(OpCodes.Ldarg_0),
-                    new(OpCodes.Ldfld, Field(typeof(Intercom), nameof(Intercom._curSpeaker))),
+                    // Player.Get(first)
+                    new(OpCodes.Ldloc_1),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
 
                     // true

--- a/EXILED/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/IntercomSpeaking.cs
@@ -38,7 +38,7 @@ namespace Exiled.Events.Patches.Events.Player
             Label returnLabel = generator.DefineLabel();
 
             const int offset = -2;
-            int index = newInstructions.FindIndex(instruction => instruction.StoresField(Field(typeof(Intercom), nameof(Intercom._curSpeaker))))) + offset;
+            int index = newInstructions.FindIndex(instruction => instruction.StoresField(Field(typeof(Intercom), nameof(Intercom._curSpeaker)))) + offset;
 
             newInstructions.InsertRange(
                 index,


### PR DESCRIPTION
## Description
**Describe the changes** 
When IsAllowed = false, a start sound was produced, which should not be there.
I changed the event call location from IntercomState.Starting to IntercomState.Ready after receiving the ReferenceHub 

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Highly unlikely.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
