### PR TITLE
feat: Map.Broadcast(ushort, Func<Player, string>) overload.

### DIFF
--- a/EXILED/Exiled.API/Features/Map.cs
+++ b/EXILED/Exiled.API/Features/Map.cs
@@ -134,6 +134,17 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Broadcasts delegate invocation result to all <see cref="Player">players</see>.
+        /// </summary>
+        /// <param name="duration">The duration in seconds.</param>
+        /// <param name="func">The delegate whose invocation result will be the message.</param>
+        public static void Broadcast(ushort duration, Func<Player, string> func)
+        {
+            foreach (Player player in Player.List)
+                player.Broadcast(duration, func.Invoke(player));
+        }
+
+        /// <summary>
         /// Shows a hint to all <see cref="Player">players</see>.
         /// </summary>
         /// <param name="message">The message that will be broadcasted (supports Unity Rich Text formatting).</param>

--- a/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------
+// <copyright file="RemoteAdminNpcCommandAddToDictionaryFix.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using CommandSystem.Commands.RemoteAdmin.Dummies;
+    using Exiled.API.Features;
+    using Exiled.API.Features.Pools;
+    using GameCore;
+    using HarmonyLib;
+    using UnityEngine;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    /// Fix to add <see cref="Npc"/>> created via RA to the <see cref="Npc.List"/>>.
+    /// </summary>
+    [HarmonyPatch(typeof(SpawnDummyCommand), nameof(SpawnDummyCommand.Execute))]
+    internal class RemoteAdminNpcCommandAddToDictionaryFix
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            MethodBase method = Method(typeof(DummyUtils), nameof(DummyUtils.SpawnDummy));
+
+            // call ReferenceHub GameCore.DummyUtils::SpawnDummy(string)
+            int index = newInstructions.FindIndex(instruction =>
+                                        instruction.operand == (object)method) + 1;
+
+            LocalBuilder npc = generator.DeclareLocal(typeof(Npc));
+
+            // pop
+            newInstructions.RemoveAt(index);
+
+            newInstructions.InsertRange(
+                index,
+                new CodeInstruction[]
+                    {
+                        // Npc::.ctor(ReferenceHub)
+                        new(OpCodes.Newobj,   Constructor(typeof(Npc), new[] { typeof(ReferenceHub) })),
+                        new(OpCodes.Stloc_S,  npc.LocalIndex),
+
+                        // Player.Dictionary::get_Dictionary
+                        new(OpCodes.Call,     PropertyGetter(typeof(Player), nameof(Player.Dictionary))),
+                        new(OpCodes.Ldloc_S,  npc.LocalIndex),
+
+                        // Player::GameObject_getGameObject
+                        new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.GameObject))),
+                        new(OpCodes.Ldloc_S,  npc.LocalIndex),
+
+                        // Player.Dictionary.Add(GameObject, ReferenceHub)
+                        new(OpCodes.Callvirt, Method(typeof(Dictionary<GameObject, Player>), nameof(Dictionary<GameObject, Player>.Add))),
+                    });
+
+            for (int i = 0; i < newInstructions.Count; i++)
+            {
+                yield return newInstructions[i];
+            }
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+}

--- a/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
@@ -21,7 +21,7 @@ namespace Exiled.Events.Patches.Fixes
     using static HarmonyLib.AccessTools;
 
     /// <summary>
-    /// Fix to add <see cref="Npc"/>> created via RA to the <see cref="Npc.List"/>>.
+    /// Fix to add <see cref="Npc"/> created via RA to the <see cref="Npc.List"/>.
     /// </summary>
     [HarmonyPatch(typeof(SpawnDummyCommand), nameof(SpawnDummyCommand.Execute))]
     internal static class RemoteAdminNpcCommandAddToDictionaryFix

--- a/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
@@ -24,7 +24,7 @@ namespace Exiled.Events.Patches.Fixes
     /// Fix to add <see cref="Npc"/>> created via RA to the <see cref="Npc.List"/>>.
     /// </summary>
     [HarmonyPatch(typeof(SpawnDummyCommand), nameof(SpawnDummyCommand.Execute))]
-    internal class RemoteAdminNpcCommandAddToDictionaryFix
+    internal static class RemoteAdminNpcCommandAddToDictionaryFix
     {
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
@@ -49,11 +49,11 @@ namespace Exiled.Events.Patches.Fixes
                         new(OpCodes.Newobj,   Constructor(typeof(Npc), new[] { typeof(ReferenceHub) })),
                         new(OpCodes.Stloc_S,  npc.LocalIndex),
 
-                        // Player.Dictionary::get_Dictionary
+                        // Player.Dictionary.get_Dictionary
                         new(OpCodes.Call,     PropertyGetter(typeof(Player), nameof(Player.Dictionary))),
                         new(OpCodes.Ldloc_S,  npc.LocalIndex),
 
-                        // Player::GameObject_getGameObject
+                        // Player::GameObject.get_GameObject
                         new(OpCodes.Callvirt, PropertyGetter(typeof(Player), nameof(Player.GameObject))),
                         new(OpCodes.Ldloc_S,  npc.LocalIndex),
 

--- a/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/RemoteAdminNpcCommandAddToDictionaryFix.cs
@@ -62,9 +62,7 @@ namespace Exiled.Events.Patches.Fixes
                     });
 
             for (int i = 0; i < newInstructions.Count; i++)
-            {
                 yield return newInstructions[i];
-            }
 
             ListPool<CodeInstruction>.Pool.Return(newInstructions);
         }


### PR DESCRIPTION
## Description
Added overload for Map.Broadcast(ushort, Func<Player, string>) to shorthand map-wide broadcasting.


**What is the current behavior?** (You can also link to an open issue here)
Map-wide broadcast with Player::DisplayNickname
![изображение](https://github.com/user-attachments/assets/cca88774-0db2-4287-93a9-a85dda32634e)



**What is the new behavior?** (if this is a feature change)
Map-wide broadcast with Player::DisplayNickname
![изображение](https://github.com/user-attachments/assets/e10b5a6b-8ea4-42a3-a62e-33edb78ec46e)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
