### PR TITLE
feat: `Player::TryRemoveCandy(CandyKindID)` method

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2908,19 +2908,23 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Removes specific candy from the players <see cref="Scp330Bag"/>.
+        /// Removes specific candy from the players <see cref="Scp330"/>.
         /// </summary>
         /// <param name="candyType">The <see cref="CandyKindID"/> to remove.</param>
+        /// <param name="removeAll">Remove all candy of that type.</param>
         /// <returns><see langword="true"/> if a candy was removed.</returns>
-        public bool TryRemoveCandу(CandyKindID candyType)
+        public bool TryRemoveCandу(CandyKindID candyType, bool removeAll = false)
         {
-            if (!Scp330Bag.TryGetBag(ReferenceHub, out Scp330Bag bag))
-                return false;
+            foreach (Item item in Items)
+            {
+                if (item is not Scp330 bag)
+                    continue;
 
-            bool result = bag.Candies.Remove(candyType);
-            bag.ServerRefreshBag();
+                if (bag.RemoveCandy(candyType, removeAll) > 0)
+                    return true;
+            }
 
-            return result;
+            return false;
         }
 
         /// <summary>

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2908,6 +2908,22 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Removes specific candy from the players <see cref="Scp330Bag"/>.
+        /// </summary>
+        /// <param name="candyType">The <see cref="CandyKindID"/> to remove.</param>
+        /// <returns><see langword="true"/> if a candy was removed.</returns>
+        public bool TryRemoveCandу(CandyKindID candyType)
+        {
+            if (!Scp330Bag.TryGetBag(ReferenceHub, out Scp330Bag bag))
+                return false;
+
+            bool result = bag.Candies.Remove(candyType);
+            bag.ServerRefreshBag();
+
+            return result;
+        }
+
+        /// <summary>
         /// Resets the player's inventory to the provided list of items, clearing any items it already possess.
         /// </summary>
         /// <param name="newItems">The new items that have to be added to the inventory.</param>


### PR DESCRIPTION
## Description
Added a method to remove candy from a `Player` instance.


**What is the current behavior?** (You can also link to an open issue here)
There is a method `Player::TryAddCandy(CandyKindID)`, but no method to remove candy.

**What is the new behavior?** (if this is a feature change)
Added a method to remove candy from a `Player` instance.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
