### PR TITLE
docs: Grammatical Corrections for a EnableEffect (but it targets the right branch)

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -3210,7 +3210,7 @@ namespace Exiled.API.Features
         /// <param name="intensity">The intensity of the effect will be active for.</param>
         /// <param name="duration">The amount of time the effect will be active for.</param>
         /// <param name="addDurationIfActive">If the effect is already active, setting to <see langword="true"/> will add this duration onto the effect.</param>
-        /// <returns>return if the effect has been Enable.</returns>
+        /// <returns>A bool indicating whether the effect was valid and successfully enabled.</returns>
         public bool EnableEffect(EffectType type, byte intensity, float duration = 0f, bool addDurationIfActive = false)
             => TryGetEffect(type, out StatusEffectBase statusEffect) && EnableEffect(statusEffect, intensity, duration, addDurationIfActive);
 


### PR DESCRIPTION
## Description
**Describe the changes**
Changes "return if the effect has been Enable." to "A bool indicating whether the effect was valid and successfully enabled." as the former made no grammatical sense.

**What is the current behavior? (You can also link to an open issue here)**
It makes no grammatical sense
https://discord.com/channels/656673194693885975/1350404844292411405/1350404844292411405

**What is the new behavior? (if this is a feature change)**
It makes grammatical sense, using the same return as the other EnableEffects returns.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
*Made it target the correct branch by the request from Yamato*
https://discord.com/channels/656673194693885975/1350404844292411405/1350467375329447946

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
