### PR TITLE
feat: Custom limits for armor & virtual dmg for customweapon

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomArmor.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomArmor.cs
@@ -8,13 +8,16 @@
 namespace Exiled.CustomItems.API.Features
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
 
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
+    using Exiled.API.Structs;
     using Exiled.Events.EventArgs.Player;
 
+    using InventorySystem.Items.Armor;
     using MEC;
 
     /// <summary>
@@ -55,6 +58,16 @@ namespace Exiled.CustomItems.API.Features
         [Description("The value must be above 0 and below 100")]
         public virtual int VestEfficacy { get; set; } = 80;
 
+        /// <summary>
+        /// Gets or sets the Ammunition limit the player have.
+        /// </summary>
+        public virtual List<ArmorAmmoLimit> AmmoLimits { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the Item Category limit the player have.
+        /// </summary>
+        public virtual List<BodyArmor.ArmorCategoryLimitModifier> CategoryLimits { get; set; } = new();
+
         /// <inheritdoc />
         public override void Give(Player player, bool displayMessage = true)
         {
@@ -65,6 +78,12 @@ namespace Exiled.CustomItems.API.Features
 
             armor.VestEfficacy = VestEfficacy;
             armor.HelmetEfficacy = HelmetEfficacy;
+
+            if (AmmoLimits.Count != 0)
+                armor.AmmoLimits = AmmoLimits;
+
+            if (AmmoLimits.Count != 0)
+                armor.CategoryLimits = CategoryLimits;
 
             player.AddItem(armor);
 

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -52,7 +52,7 @@ namespace Exiled.CustomItems.API.Features
         /// <summary>
         /// Gets or sets the weapon damage.
         /// </summary>
-        public abstract float Damage { get; set; }
+        public virtual float Damage { get; set; } = float.NaN;
 
         /// <summary>
         /// Gets or sets a value indicating how big of a clip the weapon will have.
@@ -205,7 +205,7 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="ev"><see cref="HurtingEventArgs"/>.</param>
         protected virtual void OnHurting(HurtingEventArgs ev)
         {
-            if (ev.IsAllowed && Damage > 0f)
+            if (ev.IsAllowed && Damage != float.NaN)
                 ev.Amount = Damage;
         }
 


### PR DESCRIPTION
## Description
Adding AmmoLimits, CategoryLimits to CustomArmor
Damage in CustomWeapon not neccessary now, defualt NaN to not override (can be 0 dmg)


**What is the current behavior?** (You can also link to an open issue here)
-

**What is the new behavior?** (if this is a feature change)
Can change the ammo and category limit in Armor
Can do 0 damage in custom weapon

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
