### PR TITLE
feat: New argument specifying whether breakneckspeed is turned on or off

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Scp173/UsingBreakneckSpeedsEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp173/UsingBreakneckSpeedsEventArgs.cs
@@ -22,13 +22,17 @@ namespace Exiled.Events.EventArgs.Scp173
         /// <param name="player">
         /// <inheritdoc cref="Player" />
         /// </param>
+        /// <param name="isActivationRequested">
+        /// <inheritdoc cref="IsActivationRequested" />
+        /// </param>
         /// <param name="isAllowed">
         /// <inheritdoc cref="IsAllowed" />
         /// </param>
-        public UsingBreakneckSpeedsEventArgs(Player player, bool isAllowed = true)
+        public UsingBreakneckSpeedsEventArgs(Player player, bool isActivationRequested, bool isAllowed = true)
         {
             Player = player;
             Scp173 = player.Role.As<Scp173Role>();
+            IsActivationRequested = isActivationRequested;
             IsAllowed = isAllowed;
         }
 
@@ -36,6 +40,11 @@ namespace Exiled.Events.EventArgs.Scp173
         /// Gets or sets a value indicating whether the player can use breakneck speeds.
         /// </summary>
         public bool IsAllowed { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether the player is attempting to activate breakneck speeds.
+        /// </summary>
+        public bool IsActivationRequested { get; }
 
         /// <summary>
         /// Gets the player who's using breakneck speeds.

--- a/EXILED/Exiled.Events/EventArgs/Scp173/UsingBreakneckSpeedsEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp173/UsingBreakneckSpeedsEventArgs.cs
@@ -42,7 +42,7 @@ namespace Exiled.Events.EventArgs.Scp173
         public bool IsAllowed { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether gets whether the player is attempting to activate breakneck speeds.
+        /// Gets a value indicating whether the player is attempting to activate breakneck speeds.
         /// </summary>
         public bool IsActivationRequested { get; }
 

--- a/EXILED/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
@@ -54,6 +54,9 @@ namespace Exiled.Events.Patches.Events.Scp173
                     new(OpCodes.Call, PropertyGetter(typeof(StandardSubroutine<Scp173Role>), nameof(StandardSubroutine<Scp173Role>.Owner))),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
 
+                    // value attempted to be set
+                    new(OpCodes.Ldarg_1),
+
                     // this.Cooldown.Remaining == 0
                     new(OpCodes.Ldarg_0),
                     new(OpCodes.Ldfld, Field(typeof(Scp173BreakneckSpeedsAbility), nameof(Scp173BreakneckSpeedsAbility.Cooldown))),
@@ -61,7 +64,7 @@ namespace Exiled.Events.Patches.Events.Scp173
                     new(OpCodes.Ldc_R4, 0f),
                     new(OpCodes.Ceq),
 
-                    // UsingBreakneckSpeedsEventArgs ev = new(Player, bool)
+                    // UsingBreakneckSpeedsEventArgs ev = new(Player, bool, bool)
                     new(OpCodes.Newobj, GetDeclaredConstructors(typeof(UsingBreakneckSpeedsEventArgs))[0]),
                     new(OpCodes.Dup),
 

--- a/EXILED/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp173/UsingBreakneckSpeeds.cs
@@ -54,7 +54,7 @@ namespace Exiled.Events.Patches.Events.Scp173
                     new(OpCodes.Call, PropertyGetter(typeof(StandardSubroutine<Scp173Role>), nameof(StandardSubroutine<Scp173Role>.Owner))),
                     new(OpCodes.Call, Method(typeof(Player), nameof(Player.Get), new[] { typeof(ReferenceHub) })),
 
-                    // value attempted to be set
+                    // value to be set (will the ability turn on or off)
                     new(OpCodes.Ldarg_1),
 
                     // this.Cooldown.Remaining == 0


### PR DESCRIPTION
## Description
**Describe the changes** 
Adds a new argument to the usingbreakneckspeed event so that we can determine whether the capability is opening or closing

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)
Adding IsActivationRequested args to UsingBreakneckSpeeds event

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
