### PR TITLE
feat: Fix wrong arg & Scp1344 Status change Prefix/Postfix to Transpiler

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -18,7 +18,7 @@ namespace Exiled.Events.EventArgs.Scp1344
     /// <summary>
     /// Contains all information after SCP-1344 status changing.
     /// </summary>
-    public class ChangedStatusEventArgs : IScp1344Event, IPlayerEvent
+    public class ChangedStatusEventArgs : IScp1344Event, IPlayerEvent, IDeniableEvent
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChangedStatusEventArgs" /> class.

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -53,7 +53,7 @@ namespace Exiled.Events.EventArgs.Scp1344
         public Scp1344 Scp1344 { get; }
 
         /// <inheritdoc/>
-        [Obsolete]
+        [Obsolete("Please use ChangingStatusEventArgs::IsAllowed instead of this", true)]
         public bool IsAllowed { get; set; }
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -7,8 +7,11 @@
 
 namespace Exiled.Events.EventArgs.Scp1344
 {
+    using System;
+    
     using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs.Interfaces;
+    
     using InventorySystem.Items;
     using InventorySystem.Items.Usables.Scp1344;
 

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -49,5 +49,13 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// Gets Scp1344 item.
         /// </summary>
         public Scp1344 Scp1344 { get; }
+
+        /// <summary>
+        /// Do not use this parameter, it is incorrect and does not work.
+        /// </summary>
+        [Obsolete]
+        #pragma warning disable SA1623 // Property summary documentation should match accessors
+        public bool IsAllowed { get; set; }
+        #pragma warning restore SA1623 // Property summary documentation should match accessors
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -27,9 +27,8 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// <param name="scp1344Status"><inheritdoc cref="InventorySystem.Items.Usables.Scp1344.Scp1344Status"/></param>
         public ChangedStatusEventArgs(ItemBase item, Scp1344Status scp1344Status)
         {
-            Item = Item.Get(item);
-            Scp1344 = Item as Scp1344;
-            Player = Item.Owner;
+            Scp1344 = Item.Get<Scp1344>(item);
+            Player = Scp1344.Owner;
             Scp1344Status = scp1344Status;
         }
 
@@ -41,7 +40,7 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// <summary>
         /// Gets the item.
         /// </summary>
-        public Item Item { get; }
+        public Item Item => Scp1344;
 
         /// <summary>
         /// Gets the player in owner of the item.

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -9,23 +9,24 @@ namespace Exiled.Events.EventArgs.Scp1344
 {
     using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs.Interfaces;
+    using InventorySystem.Items;
     using InventorySystem.Items.Usables.Scp1344;
 
     /// <summary>
     /// Contains all information after SCP-1344 status changing.
     /// </summary>
-    public class ChangedStatusEventArgs : IScp1344Event, IPlayerEvent, IDeniableEvent
+    public class ChangedStatusEventArgs : IScp1344Event, IPlayerEvent
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChangedStatusEventArgs" /> class.
         /// </summary>
         /// <param name="item"><inheritdoc cref="Item"/></param>
         /// <param name="scp1344Status"><inheritdoc cref="InventorySystem.Items.Usables.Scp1344.Scp1344Status"/></param>
-        public ChangedStatusEventArgs(Item item, Scp1344Status scp1344Status)
+        public ChangedStatusEventArgs(ItemBase item, Scp1344Status scp1344Status)
         {
-            Item = item;
-            Scp1344 = item as Scp1344;
-            Player = item.Owner;
+            Item = Item.Get(item);
+            Scp1344 = Item as Scp1344;
+            Player = Item.Owner;
             Scp1344Status = scp1344Status;
         }
 
@@ -48,8 +49,5 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// Gets Scp1344 item.
         /// </summary>
         public Scp1344 Scp1344 { get; }
-
-        /// <inheritdoc/>
-        public bool IsAllowed { get; set; }
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -52,12 +52,8 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// </summary>
         public Scp1344 Scp1344 { get; }
 
-        /// <summary>
-        /// Do not use this parameter, it is incorrect and does not work.
-        /// </summary>
+        /// <inheritdoc/>
         [Obsolete]
-        #pragma warning disable SA1623 // Property summary documentation should match accessors
         public bool IsAllowed { get; set; }
-        #pragma warning restore SA1623 // Property summary documentation should match accessors
     }
 }

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -11,7 +11,7 @@ namespace Exiled.Events.EventArgs.Scp1344
     
     using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs.Interfaces;
-    
+
     using InventorySystem.Items;
     using InventorySystem.Items.Usables.Scp1344;
 

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangedStatusEventArgs.cs
@@ -8,7 +8,7 @@
 namespace Exiled.Events.EventArgs.Scp1344
 {
     using System;
-    
+
     using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs.Interfaces;
 

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangingStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangingStatusEventArgs.cs
@@ -26,9 +26,8 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
         public ChangingStatusEventArgs(ItemBase item, Scp1344Status scp1344StatusNew, Scp1344Status scp1344StatusOld, bool isAllowed = true)
         {
-            Item = Item.Get(item);
-            Scp1344 = Item as Scp1344;
-            Player = Item.Owner;
+            Scp1344 = Item.Get<Scp1344>(item); 
+            Player = Scp1344.Owner;
             Scp1344StatusNew = scp1344StatusNew;
             Scp1344StatusOld = scp1344StatusOld;
             IsAllowed = isAllowed;
@@ -47,7 +46,7 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// <summary>
         /// Gets the item.
         /// </summary>
-        public Item Item { get; }
+        public Item Item => Scp1344;
 
         /// <summary>
         /// Gets the player in owner of the item.

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangingStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangingStatusEventArgs.cs
@@ -26,7 +26,7 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
         public ChangingStatusEventArgs(ItemBase item, Scp1344Status scp1344StatusNew, Scp1344Status scp1344StatusOld, bool isAllowed = true)
         {
-            Scp1344 = Item.Get<Scp1344>(item); 
+            Scp1344 = Item.Get<Scp1344>(item);
             Player = Scp1344.Owner;
             Scp1344StatusNew = scp1344StatusNew;
             Scp1344StatusOld = scp1344StatusOld;

--- a/EXILED/Exiled.Events/EventArgs/Scp1344/ChangingStatusEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp1344/ChangingStatusEventArgs.cs
@@ -9,6 +9,7 @@ namespace Exiled.Events.EventArgs.Scp1344
 {
     using Exiled.API.Features.Items;
     using Exiled.Events.EventArgs.Interfaces;
+    using InventorySystem.Items;
     using InventorySystem.Items.Usables.Scp1344;
 
     /// <summary>
@@ -23,11 +24,11 @@ namespace Exiled.Events.EventArgs.Scp1344
         /// <param name="scp1344StatusNew"><inheritdoc cref="Scp1344StatusNew"/></param>
         /// <param name="scp1344StatusOld"><inheritdoc cref="Scp1344StatusOld"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public ChangingStatusEventArgs(Item item, Scp1344Status scp1344StatusNew, Scp1344Status scp1344StatusOld, bool isAllowed = true)
+        public ChangingStatusEventArgs(ItemBase item, Scp1344Status scp1344StatusNew, Scp1344Status scp1344StatusOld, bool isAllowed = true)
         {
-            Item = item;
-            Scp1344 = item as Scp1344;
-            Player = item.Owner;
+            Item = Item.Get(item);
+            Scp1344 = Item as Scp1344;
+            Player = Item.Owner;
             Scp1344StatusNew = scp1344StatusNew;
             Scp1344StatusOld = scp1344StatusOld;
             IsAllowed = isAllowed;

--- a/EXILED/Exiled.Events/Patches/Events/Scp1344/Status.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp1344/Status.cs
@@ -5,15 +5,21 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
-
 namespace Exiled.Events.Patches.Events.Scp1344
 {
-    using Exiled.API.Features.Items;
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Scp1344;
     using HarmonyLib;
+
     using InventorySystem.Items.Usables.Scp1344;
+
+    using static HarmonyLib.AccessTools;
 
     /// <summary>
     /// Patches <see cref="Scp1344Item.Status"/>.
@@ -25,18 +31,81 @@ namespace Exiled.Events.Patches.Events.Scp1344
     [HarmonyPatch(typeof(Scp1344Item), nameof(Scp1344Item.Status), MethodType.Setter)]
     internal static class Status
     {
-        private static bool Prefix(Scp1344Item __instance, ref Scp1344Status value)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
-            ChangingStatusEventArgs ev = new(Item.Get(__instance), value, __instance._status);
-            Handlers.Scp1344.OnChangingStatus(ev);
-            value = ev.Scp1344StatusNew;
-            return ev.IsAllowed;
-        }
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
 
-        private static void Postfix(Scp1344Item __instance, ref Scp1344Status value)
-        {
-            ChangedStatusEventArgs ev = new(Item.Get(__instance), value);
-            Handlers.Scp1344.OnChangedStatus(ev);
+            // Declare local variable for ChangingStatusEventArgs
+            LocalBuilder ev = generator.DeclareLocal(typeof(ChangingStatusEventArgs));
+
+            // Continue label for isAllowed check
+            Label continueLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(0, new CodeInstruction[]
+            {
+                    // this.Scp1344Item
+                    new(OpCodes.Ldarg_0),
+
+                    // value to be set
+                    new(OpCodes.Ldarg_1),
+
+                    // this._status
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(Scp1344Item), nameof(Scp1344Item._status))),
+
+                     // true (IsAllowed)
+                    new(OpCodes.Ldc_I4_1),
+
+                    // ChangingStatusEventArgs ev = new(this.Item, value, this._status, isallowed)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangingStatusEventArgs))[0]),
+                    new(OpCodes.Dup),
+                    new(OpCodes.Stloc_S, ev.LocalIndex),
+
+                    // Handlers.Scp1344.OnChangingStatus(ev)
+                    new(OpCodes.Call, Method(typeof(Handlers.Scp1344), nameof(Handlers.Scp1344.OnChangingStatus))),
+
+                    // if (!ev.IsAllowed) return;
+                    new(OpCodes.Ldloc_S, ev.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingStatusEventArgs), nameof(ChangingStatusEventArgs.IsAllowed))),
+                    new(OpCodes.Brtrue_S, continueLabel),
+
+                    // Return;
+                    new(OpCodes.Ret),
+
+                    // continue label
+                    new CodeInstruction(OpCodes.Nop).WithLabels(continueLabel),
+
+                    // value = ev.Scp1344StatusNew;
+                    new(OpCodes.Ldloc_S, ev.LocalIndex),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(ChangingStatusEventArgs), nameof(ChangingStatusEventArgs.Scp1344StatusNew))),
+                    new(OpCodes.Starg_S, 1),
+            });
+
+            // this.ServerChangeStatus(value) index
+            MethodInfo changeStatusMethod = Method(typeof(Scp1344Item), nameof(Scp1344Item.ServerChangeStatus));
+            int offset = 1;
+            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Call && i.operand is MethodInfo method && method == changeStatusMethod) + offset;
+
+            newInstructions.InsertRange(index, new CodeInstruction[]
+            {
+                    // this.Scp1344Item
+                    new(OpCodes.Ldarg_0),
+
+                    // value to be set
+                    new(OpCodes.Ldarg_1),
+
+                    // ChangedStatusEventArgs ev = new(this.Item, value)
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(ChangedStatusEventArgs))[0]),
+
+                    // Handlers.Scp1344.OnChangedStatus(ev)
+                    new(OpCodes.Call, Method(typeof(Handlers.Scp1344), nameof(Handlers.Scp1344.OnChangedStatus))),
+            });
+
+            // Return the new instructions
+            foreach (CodeInstruction newcode in newInstructions)
+                yield return newcode;
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
         }
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 
Removed the incorrect and unused IsAllowed argument from the Scp1344.ChangedStatus event.
Refactored the ChangingStatus (prefix) and ChangedStatus (postfix) patches into a unified transpiler implementation.

**What is the current behavior?** (You can also link to an open issue here)
The ChangedStatus event incorrectly includes an IsAllowed argument, which is not used and may cause confusion.
Event hooks are separated and not streamlined within a single transpiler.

**What is the new behavior?** (if this is a feature change)
Events are now handled within a single, unified transpiler for better clarity and control.
The ChangedStatus event has been cleaned up to include only relevant data.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
This cleanup improves maintainability and reduces redundancy in the event patching system for SCP-1344 status changes.

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
