### PR TITLE
fix: InvalidOperationException in UnregisterItems

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem.cs
@@ -453,7 +453,7 @@ namespace Exiled.CustomItems.API.Features
         {
             List<CustomItem> unregisteredItems = new();
 
-            foreach (CustomItem customItem in Registered)
+            foreach (CustomItem customItem in Registered.ToList())
             {
                 customItem.TryUnregister();
                 unregisteredItems.Add(customItem);


### PR DESCRIPTION
## Description
**Describe the changes**  
Fixed `UnregisterItems` to avoid modifying `Registered` during iteration by using a copy.

**What is the current behavior?**  
`UnregisterItems` logs an `InvalidOperationException` when `TryUnregister` modifies `Registered`.

**What is the new behavior?**  
Iterates over a copy of `Registered`, preventing the error.

**Does this PR introduce a breaking change?**  
No, no changes needed for users.

**Other information**:  
Fixes a collection iteration error.

<br />

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentations

<br />

## Submission checklist
- [x] Project compiles
- [x] Tested and works

### Patches
- [x] No IL patching errors

### Other
- [ ] Needs more testing