### PR TITLE
feat: New Player::AddRegeneration method

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -3498,6 +3498,21 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Adds a new <see cref="RegenerationProcess"/> to the player.
+        /// </summary>
+        /// <param name="starttime">The delay before regeneration starts (in seconds).</param>
+        /// <param name="rate">Health points regenerated per second.</param>
+        /// <param name="duration">Total duration of the regeneration (in seconds).</param>
+        /// <param name="speedMultiplier">How fast the regeneration progresses (default is 1.0).</param>
+        /// <param name="healthPointsMultiplier">Multiplier for HP amount being regenerated (default is 1.0).</param>
+        public void AddRegeneration(float starttime = 0f, float rate = 1f, float duration = 1f, float speedMultiplier = 1f, float healthPointsMultiplier = 1f)
+        {
+            AnimationCurve regenCurve = AnimationCurve.Constant(starttime, duration, rate);
+            UsableItemsController.GetHandler(ReferenceHub)
+                .ActiveRegenerations.Add(new RegenerationProcess(regenCurve, speedMultiplier, healthPointsMultiplier));
+        }
+        
+        /// <summary>
         /// Reconnects the player to the server. Can be used to redirect them to another server on a different port but same IP.
         /// </summary>
         /// <param name="newPort">New port.</param>

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -3511,7 +3511,7 @@ namespace Exiled.API.Features
             UsableItemsController.GetHandler(ReferenceHub)
                 .ActiveRegenerations.Add(new RegenerationProcess(regenCurve, speedMultiplier, healthPointsMultiplier));
         }
-        
+
         /// <summary>
         /// Reconnects the player to the server. Can be used to redirect them to another server on a different port but same IP.
         /// </summary>


### PR DESCRIPTION
## Description
**Describe the changes** 
Added a method to apply health regeneration to players via `RegenerationProcess`, allowing for customizable delay, rate, duration, speed multiplier, and HP multiplier.

**What is the current behavior?** (You can also link to an open issue here)
No built-in or easily accessible method to apply custom regeneration effects to players through EXILED.

**What is the new behavior?** (if this is a feature change)
Players can now receive configurable health regeneration via `AddRegeneration()` extension method.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes. New functionality added in a backward-compatible way.

**Other information**:
Designed as an extension for easier integration with plugins and custom commands.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
