### PR TITLE
feat: SSS can be registered through Player class

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -19,6 +19,7 @@ namespace Exiled.API.Features
     using DamageHandlers;
     using Enums;
     using Exiled.API.Features.Core.Interfaces;
+    using Exiled.API.Features.Core.UserSettings;
     using Exiled.API.Features.CustomStats;
     using Exiled.API.Features.Doors;
     using Exiled.API.Features.Hazards;
@@ -3603,6 +3604,24 @@ namespace Exiled.API.Features
         /// </summary>
         /// <typeparam name="T">Object for teleport.</typeparam>
         public void RandomTeleport<T>() => RandomTeleport(typeof(T));
+
+        /// <summary>
+        /// Registers a collection of Server-side specific settings for the player.
+        /// </summary>
+        /// <param name="settings">The collection of Server-side specific settings to register.</param>
+        public void RegisterSettings(IEnumerable<SettingBase> settings)
+        {
+            SettingBase.Register(settings, (p) => { return p == this; });
+        }
+
+        /// <summary>
+        /// Unregisters a collection of Server-side specific settings for the player.
+        /// </summary>
+        /// <param name="settings">The collection of Server-side specific settings to unregister.</param>
+        public void UnregisterSettings(IEnumerable<SettingBase> settings)
+        {
+            SettingBase.Unregister((p) => { return p == this; }, settings);
+        }
 
         /// <inheritdoc/>
         public T AddComponent<T>(string name = "")

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -60,6 +60,7 @@ namespace Exiled.API.Features
     using Respawning.NamingRules;
     using RoundRestarting;
     using UnityEngine;
+    using UserSettings.UserInterfaceSettings;
     using Utils;
     using Utils.Networking;
     using VoiceChat;
@@ -3615,9 +3616,17 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Unregisters a collection of Server-side specific settings for the player.
+        /// Unregisters all Server-side specific settings associated with this player.
         /// </summary>
-        /// <param name="settings">The collection of Server-side specific settings to unregister.</param>
+        public void UnregisterSettings()
+        {
+            SettingBase.Unregister((p) => { return p == this; });
+        }
+
+        /// <summary>
+        /// Unregisters the specified Server-side specific settings for the player.
+        /// </summary>
+        /// <param name="settings">The collection of settings to unregister.</param>
         public void UnregisterSettings(IEnumerable<SettingBase> settings)
         {
             SettingBase.Unregister((p) => { return p == this; }, settings);

--- a/EXILED/Exiled.API/Features/Warhead.cs
+++ b/EXILED/Exiled.API/Features/Warhead.cs
@@ -187,30 +187,9 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Starts the warhead countdown.
-        /// </summary>
-        /// <param name="isAutomatic">Indicates whether the warhead is started automatically.</param>
-        /// <param name="suppressSubtitles">If <see langword="true"/>, subtitles will not be displayed during the countdown.</param>
-        /// <param name="trigger">The <see cref="ReferenceHub"/> of the entity that triggered the warhead.</param>
-        public static void Start(bool isAutomatic = false, bool suppressSubtitles = false, ReferenceHub trigger = null)
-        {
-            Controller.InstantPrepare();
-            Controller.StartDetonation(isAutomatic, suppressSubtitles, trigger);
-        }
-
-        /// <summary>
         /// Stops the warhead.
         /// </summary>
         public static void Stop() => Controller.CancelDetonation();
-
-        /// <summary>
-        /// Stops the warhead detonation process.
-        /// </summary>
-        /// <param name="disabler">
-        /// The <see cref="Player"/> who is disabling the warhead.
-        /// If <see langword="null"/>, the warhead will be stopped without a specific player reference.
-        /// </param>
-        public static void Stop(ReferenceHub disabler = null) => Controller.CancelDetonation(disabler);
 
         /// <summary>
         /// Detonates the warhead.
@@ -218,26 +197,9 @@ namespace Exiled.API.Features
         public static void Detonate() => Controller.ForceTime(0f);
 
         /// <summary>
-        /// Detonates the warhead after the specified remaining time.
-        /// </summary>
-        /// <param name="remaining">
-        /// The time in seconds until the warhead detonates.
-        /// If set to <see langword="0"/>, the warhead will detonate immediately.
-        /// </param>
-        public static void Detonate(float remaining = 0f) => Controller.ForceTime(remaining);
-
-        /// <summary>
         /// Shake all players, like if the warhead has been detonated.
         /// </summary>
         public static void Shake() => Controller.RpcShake(false);
-
-        /// <summary>
-        /// Shake all players, like if the warhead has been detonated.
-        /// </summary>
-        /// <param name="archieve">
-        /// If <see langword="true"/>, the shake effect will be archived.
-        /// </param>
-        public static void Shake(bool archieve = false) => Controller.RpcShake(archieve);
 
         /// <summary>
         /// Gets whether the provided position will be detonated by the alpha warhead.

--- a/EXILED/Exiled.API/Features/Warhead.cs
+++ b/EXILED/Exiled.API/Features/Warhead.cs
@@ -187,9 +187,30 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Starts the warhead countdown.
+        /// </summary>
+        /// <param name="isAutomatic">Indicates whether the warhead is started automatically.</param>
+        /// <param name="suppressSubtitles">If <see langword="true"/>, subtitles will not be displayed during the countdown.</param>
+        /// <param name="trigger">The <see cref="ReferenceHub"/> of the entity that triggered the warhead.</param>
+        public static void Start(bool isAutomatic = false, bool suppressSubtitles = false, ReferenceHub trigger = null)
+        {
+            Controller.InstantPrepare();
+            Controller.StartDetonation(isAutomatic, suppressSubtitles, trigger);
+        }
+
+        /// <summary>
         /// Stops the warhead.
         /// </summary>
         public static void Stop() => Controller.CancelDetonation();
+
+        /// <summary>
+        /// Stops the warhead detonation process.
+        /// </summary>
+        /// <param name="disabler">
+        /// The <see cref="Player"/> who is disabling the warhead.
+        /// If <see langword="null"/>, the warhead will be stopped without a specific player reference.
+        /// </param>
+        public static void Stop(ReferenceHub disabler = null) => Controller.CancelDetonation(disabler);
 
         /// <summary>
         /// Detonates the warhead.
@@ -197,9 +218,26 @@ namespace Exiled.API.Features
         public static void Detonate() => Controller.ForceTime(0f);
 
         /// <summary>
+        /// Detonates the warhead after the specified remaining time.
+        /// </summary>
+        /// <param name="remaining">
+        /// The time in seconds until the warhead detonates.
+        /// If set to <see langword="0"/>, the warhead will detonate immediately.
+        /// </param>
+        public static void Detonate(float remaining = 0f) => Controller.ForceTime(remaining);
+
+        /// <summary>
         /// Shake all players, like if the warhead has been detonated.
         /// </summary>
         public static void Shake() => Controller.RpcShake(false);
+
+        /// <summary>
+        /// Shake all players, like if the warhead has been detonated.
+        /// </summary>
+        /// <param name="archieve">
+        /// If <see langword="true"/>, the shake effect will be archived.
+        /// </param>
+        public static void Shake(bool archieve = false) => Controller.RpcShake(archieve);
 
         /// <summary>
         /// Gets whether the provided position will be detonated by the alpha warhead.


### PR DESCRIPTION
## Description
**Describe the changes** 
Server-side specific settings can be registered via the Player class.

**What is the current behavior?** (You can also link to an open issue here)
The SSS system could only be applied to players through the SettingBase class.

**What is the new behavior?** (if this is a feature change)
Two functions have been added:
RegisterSettings(IEnumerable<SettingBase> settings)
UnregisterSettings(IEnumerable<SettingBase> settings)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
❌

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
