### PR TITLE
fix: 'Hub' command gives RCE access to host machine

### DIFF
--- a/EXILED/Exiled.Events/Commands/Hub/Hub.cs
+++ b/EXILED/Exiled.Events/Commands/Hub/Hub.cs
@@ -45,12 +45,6 @@ namespace Exiled.Events.Commands.Hub
         /// <inheritdoc/>
         protected override bool ExecuteParent(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
-            if (sender is not ServerConsoleSender || Environment.StackTrace.Contains(nameof(RconCommand)) || Environment.StackTrace.Contains($"{nameof(Server)}.{nameof(Server.ExecuteCommand)}"))
-            {
-                response = "EXILED hub can only be used directly through the game console!";
-                return false;
-            }
-
             response = "Please, specify a valid subcommand! Available ones: install";
             return false;
         }

--- a/EXILED/Exiled.Events/Commands/Hub/Hub.cs
+++ b/EXILED/Exiled.Events/Commands/Hub/Hub.cs
@@ -10,11 +10,12 @@ namespace Exiled.Events.Commands.Hub
     using System;
 
     using CommandSystem;
+    using CommandSystem.Commands.RemoteAdmin;
+    using Exiled.API.Features;
 
     /// <summary>
     /// The EXILED hub command.
     /// </summary>
-    [CommandHandler(typeof(RemoteAdminCommandHandler))]
     [CommandHandler(typeof(GameConsoleCommandHandler))]
     public class Hub : ParentCommand
     {
@@ -44,6 +45,12 @@ namespace Exiled.Events.Commands.Hub
         /// <inheritdoc/>
         protected override bool ExecuteParent(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
+            if (sender is not ServerConsoleSender || Environment.StackTrace.Contains(nameof(RconCommand)) || Environment.StackTrace.Contains($"{nameof(Server)}.{nameof(Server.ExecuteCommand)}"))
+            {
+                response = "EXILED hub can only be used directly through the game console!";
+                return false;
+            }
+
             response = "Please, specify a valid subcommand! Available ones: install";
             return false;
         }

--- a/EXILED/Exiled.Events/Commands/Hub/Hub.cs
+++ b/EXILED/Exiled.Events/Commands/Hub/Hub.cs
@@ -10,8 +10,6 @@ namespace Exiled.Events.Commands.Hub
     using System;
 
     using CommandSystem;
-    using CommandSystem.Commands.RemoteAdmin;
-    using Exiled.API.Features;
 
     /// <summary>
     /// The EXILED hub command.

--- a/EXILED/Exiled.Events/Commands/Hub/Install.cs
+++ b/EXILED/Exiled.Events/Commands/Hub/Install.cs
@@ -13,7 +13,7 @@ namespace Exiled.Events.Commands.Hub
     using System.Net.Http;
 
     using CommandSystem;
-
+    using CommandSystem.Commands.RemoteAdmin;
     using Exiled.API.Features;
     using Exiled.Events.Commands.Hub.HubApi.Models;
     using Exiled.Loader;
@@ -54,6 +54,12 @@ namespace Exiled.Events.Commands.Hub
             if (!sender.CheckPermission(permission) && sender is PlayerCommandSender playerSender && !playerSender.FullPermissions)
             {
                 response = $"You don't have permissions to install the plugins. Required permission node: \"{permission}\".";
+                return false;
+            }
+
+            if (sender is not ServerConsoleSender || Environment.StackTrace.Contains(nameof(RconCommand)) || Environment.StackTrace.Contains($"{nameof(Server)}.{nameof(Server.ExecuteCommand)}"))
+            {
+                response = "EXILED hub can only be used directly through the game console!";
                 return false;
             }
 


### PR DESCRIPTION
## Description
**Describe the changes** 
Prevent Exiled hub command from being used through RemoteAdmin/`Server.ExecuteCommand`/`RconComand` as it grants RCE access to the host machine

**What is the current behavior?** (You can also link to an open issue here)
Exiled hub command gives RCE access (full user access) to anyone with full RemoteAdmin permissions

**What is the new behavior?** (if this is a feature change)
It doesn't

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Other
- [ ] Still requires more testing
