### PR TITLE
feat: Custom Weapon Attachments additions.

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -3278,7 +3278,7 @@ namespace Exiled.API.Features
         /// <param name="intensity">The intensity of the effect will be active for.</param>
         /// <param name="duration">The amount of time the effect will be active for.</param>
         /// <param name="addDurationIfActive">If the effect is already active, setting to <see langword="true"/> will add this duration onto the effect.</param>
-        /// <returns>return if the effect has been Enable.</returns>
+        /// <returns>A bool indicating whether the effect was valid and successfully enabled.</returns>
         public bool EnableEffect(EffectType type, byte intensity, float duration = 0f, bool addDurationIfActive = false)
             => TryGetEffect(type, out StatusEffectBase statusEffect) && EnableEffect(statusEffect, intensity, duration, addDurationIfActive);
 

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -5,8 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Exiled.Events.EventArgs.Item;
-
 namespace Exiled.CustomItems.API.Features
 {
     using System;
@@ -18,6 +16,7 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.API.Features.DamageHandlers;
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
+    using Exiled.Events.EventArgs.Item;
     using Exiled.Events.EventArgs.Player;
     using InventorySystem;
     using InventorySystem.Items.Firearms.Attachments;
@@ -153,7 +152,7 @@ namespace Exiled.CustomItems.API.Features
             Exiled.Events.Handlers.Player.Shooting += OnInternalShooting;
             Exiled.Events.Handlers.Player.Shot += OnInternalShot;
             Exiled.Events.Handlers.Player.Hurting += OnInternalHurting;
-            Exiled.Events.Handlers.Item.ChangingAttachments += OnInternalAttachmentChanging;
+            Exiled.Events.Handlers.Item.ChangingAttachments += OnInternalChangingAttachment;
 
             base.SubscribeEvents();
         }
@@ -166,7 +165,7 @@ namespace Exiled.CustomItems.API.Features
             Exiled.Events.Handlers.Player.Shooting -= OnInternalShooting;
             Exiled.Events.Handlers.Player.Shot -= OnInternalShot;
             Exiled.Events.Handlers.Player.Hurting -= OnInternalHurting;
-            Exiled.Events.Handlers.Item.ChangingAttachments -= OnInternalAttachmentChanging;
+            Exiled.Events.Handlers.Item.ChangingAttachments -= OnInternalChangingAttachment;
 
             base.UnsubscribeEvents();
         }
@@ -217,7 +216,7 @@ namespace Exiled.CustomItems.API.Features
         /// Handles attachment changing for custom weapons.
         /// </summary>
         /// <param name="ev"><see cref="ChangingAttachmentsEventArgs"/>.</param>
-        protected virtual void OnAttachmentChanging(ChangingAttachmentsEventArgs ev)
+        protected virtual void OnChangingAttachment(ChangingAttachmentsEventArgs ev)
         {
         }
 
@@ -334,12 +333,12 @@ namespace Exiled.CustomItems.API.Features
             OnHurting(ev);
         }
 
-        private void OnInternalAttachmentChanging(ChangingAttachmentsEventArgs ev)
+        private void OnInternalChangingAttachment(ChangingAttachmentsEventArgs ev)
         {
             if (!Check(ev.Player.CurrentItem))
                 return;
 
-            OnAttachmentChanging(ev);
+            OnChangingAttachment(ev);
         }
     }
 }

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Exiled.Events.EventArgs.Item;
+
 namespace Exiled.CustomItems.API.Features
 {
     using System;
@@ -151,6 +153,7 @@ namespace Exiled.CustomItems.API.Features
             Exiled.Events.Handlers.Player.Shooting += OnInternalShooting;
             Exiled.Events.Handlers.Player.Shot += OnInternalShot;
             Exiled.Events.Handlers.Player.Hurting += OnInternalHurting;
+            Exiled.Events.Handlers.Item.ChangingAttachments += OnInternalAttachmentChanging;
 
             base.SubscribeEvents();
         }
@@ -163,6 +166,7 @@ namespace Exiled.CustomItems.API.Features
             Exiled.Events.Handlers.Player.Shooting -= OnInternalShooting;
             Exiled.Events.Handlers.Player.Shot -= OnInternalShot;
             Exiled.Events.Handlers.Player.Hurting -= OnInternalHurting;
+            Exiled.Events.Handlers.Item.ChangingAttachments -= OnInternalAttachmentChanging;
 
             base.UnsubscribeEvents();
         }
@@ -207,6 +211,14 @@ namespace Exiled.CustomItems.API.Features
         {
             if (ev.IsAllowed && Damage > 0f)
                 ev.Amount = Damage;
+        }
+
+        /// <summary>
+        /// Handles attachment changing for custom weapons.
+        /// </summary>
+        /// <param name="ev"><see cref="ChangingAttachmentsEventArgs"/>.</param>
+        protected virtual void OnAttachmentChanging(ChangingAttachmentsEventArgs ev)
+        {
         }
 
         private void OnInternalReloading(ReloadingWeaponEventArgs ev)
@@ -320,6 +332,14 @@ namespace Exiled.CustomItems.API.Features
             }
 
             OnHurting(ev);
+        }
+
+        private void OnInternalAttachmentChanging(ChangingAttachmentsEventArgs ev)
+        {
+            if (!Check(ev.Player.CurrentItem))
+                return;
+
+            OnAttachmentChanging(ev);
         }
     }
 }

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -5,6 +5,9 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Numerics;
+using Exiled.API.Features.Items;
+
 namespace Exiled.CustomRoles.API.Features
 {
     using System;
@@ -535,7 +538,14 @@ namespace Exiled.CustomRoles.API.Features
                     foreach (string itemName in Inventory)
                     {
                         Log.Debug($"{Name}: Adding {itemName} to inventory.");
-                        TryAddItem(player, itemName);
+                        if (TryAddItem(player, itemName) && CustomItem.TryGet(itemName, out CustomItem? customItem) && customItem is CustomWeapon customWeapon)
+                        {
+                            if (player.CurrentItem is Firearm firearm && !customWeapon.Attachments.IsEmpty())
+                            {
+                                firearm.AddAttachment(customWeapon.Attachments);
+                                Log.Debug($"{Name}: Applied attachments to {itemName}.");
+                            }
+                        }
                     }
 
                     if (Ammo.Count > 0)

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -5,9 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Numerics;
-using Exiled.API.Features.Items;
-
 namespace Exiled.CustomRoles.API.Features
 {
     using System;
@@ -20,6 +17,7 @@ namespace Exiled.CustomRoles.API.Features
     using Exiled.API.Extensions;
     using Exiled.API.Features;
     using Exiled.API.Features.Attributes;
+    using Exiled.API.Features.Items;
     using Exiled.API.Features.Pools;
     using Exiled.API.Features.Spawn;
     using Exiled.API.Interfaces;


### PR DESCRIPTION
## Description
**Describe the changes** 
Custom Weapons now has an protected override for changing attachments
Custom Roles that are given Custom Weapon(s) on spawn, will now enforce fixed attachments if the Custom Weapon has defined attachments

**What is the current behavior?** (You can also link to an open issue here)
Custom Weapons currently needs to subscribe to a new ChangingAttachmentsEventArgs
Custom Roles that spawn with Custom Weapon(s) used the user's saved attachments instead of the Custom Weapon's defined attachments if the Custom Weapon has defined attachments

**What is the new behavior?** (if this is a feature change)
Custom Weapons now has an protected override for changing attachments
Custom Roles that are given Custom Weapon(s) on spawn, will now enforce fixed attachments if the Custom Weapon has defined attachments

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
This was built and tested on Linux only.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
