### PR TITLE
feat: Adding base game All players spawned event for exiled

### DIFF
--- a/EXILED/Exiled.Events/Events.cs
+++ b/EXILED/Exiled.Events/Events.cs
@@ -73,6 +73,7 @@ namespace Exiled.Events
             Handlers.Map.ChangedIntoGrenade += Handlers.Internal.ExplodingGrenade.OnChangedIntoGrenade;
 
             CharacterClassManager.OnRoundStarted += Handlers.Server.OnRoundStarted;
+            RoleAssigner.OnPlayersSpawned += Handlers.Server.OnAllPlayersSpawned;
             WaveManager.OnWaveSpawned += Handlers.Server.OnRespawnedTeam;
             InventorySystem.InventoryExtensions.OnItemAdded += Handlers.Player.OnItemAdded;
             InventorySystem.InventoryExtensions.OnItemRemoved += Handlers.Player.OnItemRemoved;
@@ -111,6 +112,7 @@ namespace Exiled.Events
 
             InventorySystem.InventoryExtensions.OnItemAdded -= Handlers.Player.OnItemAdded;
             InventorySystem.InventoryExtensions.OnItemRemoved -= Handlers.Player.OnItemRemoved;
+            RoleAssigner.OnPlayersSpawned -= Handlers.Server.OnAllPlayersSpawned;
             WaveManager.OnWaveSpawned -= Handlers.Server.OnRespawnedTeam;
             RagdollManager.OnRagdollSpawned -= Handlers.Internal.RagdollList.OnSpawnedRagdoll;
             RagdollManager.OnRagdollRemoved -= Handlers.Internal.RagdollList.OnRemovedRagdoll;

--- a/EXILED/Exiled.Events/Handlers/Server.cs
+++ b/EXILED/Exiled.Events/Handlers/Server.cs
@@ -146,7 +146,7 @@ namespace Exiled.Events.Handlers
         /// Called after all players have spawned at the start of a new round.
         /// </summary>
         public static void OnAllPlayersSpawned() => AllPlayersSpawned.InvokeSafely();
-        
+
         /// <summary>
         /// Called before ending a round.
         /// </summary>

--- a/EXILED/Exiled.Events/Handlers/Server.cs
+++ b/EXILED/Exiled.Events/Handlers/Server.cs
@@ -33,6 +33,11 @@ namespace Exiled.Events.Handlers
         public static Event RoundStarted { get; set; } = new();
 
         /// <summary>
+        /// Invoked after all players have spawned at the start of a new round.
+        /// </summary>
+        public static Event AllPlayersSpawned { get; set; } = new();
+
+        /// <summary>
         /// Invoked before ending a round.
         /// </summary>
         public static Event<EndingRoundEventArgs> EndingRound { get; set; } = new();
@@ -137,6 +142,11 @@ namespace Exiled.Events.Handlers
         /// </summary>
         public static void OnRoundStarted() => RoundStarted.InvokeSafely();
 
+        /// <summary>
+        /// Called after all players have spawned at the start of a new round.
+        /// </summary>
+        public static void OnAllPlayersSpawned() => AllPlayersSpawned.InvokeSafely();
+        
         /// <summary>
         /// Called before ending a round.
         /// </summary>


### PR DESCRIPTION
## Description
**Describe the changes** 
Added a new AllPlayersSpawned event to EXILED. This event is triggered after all players have spawned at the start of a new round.

**What is the current behavior?** (You can also link to an open issue here)
There was no event to detect when all players had fully spawned at the beginning of a round.

**What is the new behavior?** (if this is a feature change)
Developers can now subscribe to the AllPlayersSpawned event to run code immediately after all players are ready at round start.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, this is a non-breaking feature addition.

**Other information**:
None.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
