### PR TITLE
fix: custom weapons not doing default damage when set to below 0

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -205,7 +205,7 @@ namespace Exiled.CustomItems.API.Features
         /// <param name="ev"><see cref="HurtingEventArgs"/>.</param>
         protected virtual void OnHurting(HurtingEventArgs ev)
         {
-            if (ev.IsAllowed && Damage != float.NaN)
+            if (ev.IsAllowed && Damage >= 0)
                 ev.Amount = Damage;
         }
 

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -52,7 +52,7 @@ namespace Exiled.CustomItems.API.Features
         /// <summary>
         /// Gets or sets the weapon damage.
         /// </summary>
-        public virtual float Damage { get; set; } = float.NaN;
+        public virtual float Damage { get; set; } = -1;
 
         /// <summary>
         /// Gets or sets a value indicating how big of a clip the weapon will have.


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixed custom weapons insta killing players if their damage was set below 0.

**What is the current behavior?** (You can also link to an open issue here)
Players get insta killed by custom weapons that are set to below 0 damage.

**What is the new behavior?** (if this is a feature change)
If a custom weapon damage is set to below 0 it will use the weapons default damage.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
N/A

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
