### PR TITLE
fix: KeybindSetting and RoundEnd transpiler

### DIFF
--- a/EXILED/Exiled.API/Features/Core/UserSettings/KeybindSetting.cs
+++ b/EXILED/Exiled.API/Features/Core/UserSettings/KeybindSetting.cs
@@ -25,6 +25,23 @@ namespace Exiled.API.Features.Core.UserSettings
         /// <param name="label"><inheritdoc cref="SettingBase.Label"/></param>
         /// <param name="suggested"><inheritdoc cref="KeyCode"/></param>
         /// <param name="preventInteractionOnGUI"><inheritdoc cref="PreventInteractionOnGUI"/></param>
+        /// <param name="hintDescription"><inheritdoc cref="SettingBase.HintDescription"/></param>
+        /// <param name="header"><inheritdoc cref="SettingBase.Header"/></param>
+        /// <param name="onChanged"><inheritdoc cref="SettingBase.OnChanged"/></param>
+        [Obsolete("This method will be removed next major version because of a new feature. Use the constructor with \"allowSpectator\" instead.")]
+        public KeybindSetting(int id, string label, KeyCode suggested, bool preventInteractionOnGUI, string hintDescription, HeaderSetting header, Action<Player, SettingBase> onChanged)
+            : base(new SSKeybindSetting(id, label, suggested, preventInteractionOnGUI, false, hintDescription), header, onChanged)
+        {
+            Base = (SSKeybindSetting)base.Base;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeybindSetting"/> class.
+        /// </summary>
+        /// <param name="id"><inheritdoc cref="SettingBase.Id"/></param>
+        /// <param name="label"><inheritdoc cref="SettingBase.Label"/></param>
+        /// <param name="suggested"><inheritdoc cref="KeyCode"/></param>
+        /// <param name="preventInteractionOnGUI"><inheritdoc cref="PreventInteractionOnGUI"/></param>
         /// <param name="allowSpectatorTrigger"><inheritdoc cref="AllowSpectatorTrigger"/></param>
         /// <param name="hintDescription"><inheritdoc cref="SettingBase.HintDescription"/></param>
         /// <param name="header"><inheritdoc cref="SettingBase.Header"/></param>

--- a/EXILED/Exiled.Events/Patches/Events/Server/RoundEnd.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Server/RoundEnd.cs
@@ -66,8 +66,8 @@ namespace Exiled.Events.Patches.Events.Server
                 new CodeInstruction[]
                 {
                     new(OpCodes.Call, PropertyGetter(typeof(Round), nameof(Round.IgnoredPlayers))),
-                    new(OpCodes.Ldloc_S, 19),
-                    new(OpCodes.Call, Method(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Contains))),
+                    new(OpCodes.Ldloc_S, 20),
+                    new(OpCodes.Callvirt, Method(typeof(HashSet<ReferenceHub>), nameof(HashSet<ReferenceHub>.Contains))),
                     new(OpCodes.Brtrue_S, jmp),
                 });
 


### PR DESCRIPTION
I think it all works, I ran server and no errors, I got on and ended round and no errors

## Description
**Describe the changes** 
I fix things that were broken. We still need to fix warhead switch event, but that's it as far as I know

**What is the current behavior?** (You can also link to an open issue here)
Exiled.Events doesn't patch properly and a ctor for KeybindSetting in 14.1 was gone

**What is the new behavior?** (if this is a feature change)
Exiled.Events patches properly and the ctor is back

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
