### PR TITLE
Fix DroppedItem Event

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Player/DroppingItem.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/DroppingItem.cs
@@ -107,7 +107,7 @@ namespace Exiled.Events.Patches.Events.Player
             });
 
             const int offset = 1;
-            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Stloc_1) + offset;
+            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Stloc_2) + offset;
 
             newInstructions.InsertRange(index, new CodeInstruction[]
             {
@@ -116,7 +116,7 @@ namespace Exiled.Events.Patches.Events.Player
                 new(OpCodes.Callvirt, PropertyGetter(typeof(DroppingItemEventArgs), nameof(DroppingItemEventArgs.Player))),
 
                 // ItemPickupBase
-                new(OpCodes.Ldloc_1),
+                new(OpCodes.Ldloc_2),
 
                 // ev.IsThrown
                 new(OpCodes.Ldloc_S, ev.LocalIndex),


### PR DESCRIPTION
## Description
**Describe the changes** 
- Due to LabAPI adding PlayerDroppingItemEventArgs the index of the ItemPickupBase local has been shifted up one.

**What is the current behavior?** (You can also link to an open issue here)
Incorrect local is used (LabAPI's PlayerDroppingItemEventArgs is passed to the DroppedItemEventArgs ctor)

**What is the new behavior?** (if this is a feature change)
Correct local is used (ItemPickupBase is passed to the  DroppedItemEventArgs ctor)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
