### PR TITLE
feat: Generic damage handler add new value

### DIFF
--- a/EXILED/Exiled.API/Enums/DamageType.cs
+++ b/EXILED/Exiled.API/Enums/DamageType.cs
@@ -15,8 +15,7 @@ namespace Exiled.API.Enums
     /// Identifiers for types of damage.
     /// </summary>
     /// <seealso cref="Player.Hurt(float, DamageType, string)"/>
-    /// <seealso cref="Player.Hurt(Player, float, DamageType, Features.DamageHandlers.DamageHandlerBase.CassieAnnouncement)"/>
-    /// <seealso cref="Player.Hurt(Player, float, DamageType, Features.DamageHandlers.DamageHandlerBase.CassieAnnouncement, string)"/>
+    /// <seealso cref="Player.Hurt(Player, float, DamageType, Features.DamageHandlers.DamageHandlerBase.CassieAnnouncement, string, bool)"/>
     /// <seealso cref="Player.Kill(DamageType, string)"/>
     public enum DamageType
     {

--- a/EXILED/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
+++ b/EXILED/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
@@ -12,6 +12,7 @@ namespace Exiled.API.Features.DamageHandlers
     using Footprinting;
     using Items;
 
+    using PlayerRoles;
     using PlayerRoles.PlayableScps.Scp096;
     using PlayerRoles.PlayableScps.Scp939;
 
@@ -29,6 +30,7 @@ namespace Exiled.API.Features.DamageHandlers
         private Player player;
         private DamageType damageType;
         private DamageHandlerBase.CassieAnnouncement customCassieAnnouncement;
+        private bool overrideCassieForAllRole;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericDamageHandler"/> class.
@@ -40,11 +42,13 @@ namespace Exiled.API.Features.DamageHandlers
         /// <param name="damageType"> Damage type. </param>
         /// <param name="cassieAnnouncement"> Custom cassie announcment. </param>
         /// <param name="damageText"> Text to provide to player death screen. </param>
-        public GenericDamageHandler(Player player, Player attacker, float damage, DamageType damageType, DamageHandlerBase.CassieAnnouncement cassieAnnouncement, string damageText = null)
+        /// <param name="overrideCassieForAllRole">Whether to play Cassie for non-SCPs as well.</param>
+        public GenericDamageHandler(Player player, Player attacker, float damage, DamageType damageType, DamageHandlerBase.CassieAnnouncement cassieAnnouncement, string damageText = null, bool overrideCassieForAllRole = false)
             : base(DamageTextDefault)
         {
             this.player = player;
             this.damageType = damageType;
+            this.overrideCassieForAllRole = overrideCassieForAllRole;
             cassieAnnouncement ??= DamageHandlerBase.CassieAnnouncement.Default;
             customCassieAnnouncement = cassieAnnouncement;
 
@@ -237,7 +241,7 @@ namespace Exiled.API.Features.DamageHandlers
             HandlerOutput output = base.ApplyDamage(ply);
             if (output is HandlerOutput.Death)
             {
-                if (customCassieAnnouncement?.Announcement != null)
+                if (customCassieAnnouncement?.Announcement != null && (overrideCassieForAllRole || ply.IsSCP()))
                 {
                     Cassie.Message(customCassieAnnouncement.Announcement);
                 }

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2133,18 +2133,6 @@ namespace Exiled.API.Features
         /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
         /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
         /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
-        /// <param name="deathText">The <see langword="string"/> death text to appear on <see cref="Player"/> screen.</param>
-        /// <param name="overrideCassieForAllRole">Whether to play Cassie for non-SCPs as well.</param>
-        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null, string deathText = null, bool overrideCassieForAllRole = false) =>
-            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement, deathText, overrideCassieForAllRole));
-
-        /// <summary>
-        /// Hurts the player.
-        /// </summary>
-        /// <param name="attacker">The <see cref="Player"/> attacking player.</param>
-        /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
-        /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
-        /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
         public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null) =>
             Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement));
 
@@ -2156,8 +2144,20 @@ namespace Exiled.API.Features
         /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
         /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
         /// <param name="deathText"> The <see langword="string"/> death text to appear on <see cref="Player"/> screen. </param>
-        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null, string deathText = null) =>
+        public void Hurt(Player attacker, float amount, DamageType damageType, CassieAnnouncement cassieAnnouncement, string deathText) =>
             Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement, deathText));
+
+        /// <summary>
+        /// Hurts the player.
+        /// </summary>
+        /// <param name="attacker">The <see cref="Player"/> attacking player.</param>
+        /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
+        /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
+        /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
+        /// <param name="deathText">The <see langword="string"/> death text to appear on <see cref="Player"/> screen.</param>
+        /// <param name="overrideCassieForAllRole">Whether to play Cassie for non-SCPs as well.</param>
+        public void Hurt(Player attacker, float amount, DamageType damageType, CassieAnnouncement cassieAnnouncement, string deathText, bool overrideCassieForAllRole) =>
+            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement, deathText, overrideCassieForAllRole));
 
         /// <summary>
         /// Hurts the player.

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2133,19 +2133,10 @@ namespace Exiled.API.Features
         /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
         /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
         /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
-        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null) =>
-            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement));
-
-        /// <summary>
-        /// Hurts the player.
-        /// </summary>
-        /// <param name="attacker">The <see cref="Player"/> attacking player.</param>
-        /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
-        /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
-        /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
-        /// <param name="deathText"> The <see langword="string"/> death text to appear on <see cref="Player"/> screen. </param>
-        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null, string deathText = null) =>
-            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement, deathText));
+        /// <param name="deathText">The <see langword="string"/> death text to appear on <see cref="Player"/> screen.</param>
+        /// <param name="overrideCassieForAllRole">Whether to play Cassie for non-SCPs as well.</param>
+        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null, string deathText = null, bool overrideCassieForAllRole = false) =>
+            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement, deathText, overrideCassieForAllRole));
 
         /// <summary>
         /// Hurts the player.

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2142,6 +2142,27 @@ namespace Exiled.API.Features
         /// Hurts the player.
         /// </summary>
         /// <param name="attacker">The <see cref="Player"/> attacking player.</param>
+        /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
+        /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
+        /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
+        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null) =>
+            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement));
+
+        /// <summary>
+        /// Hurts the player.
+        /// </summary>
+        /// <param name="attacker">The <see cref="Player"/> attacking player.</param>
+        /// <param name="amount">The <see langword="float"/> amount of damage to deal.</param>
+        /// <param name="damageType">The <see cref="DamageType"/> of the damage dealt.</param>
+        /// <param name="cassieAnnouncement">The <see cref="CassieAnnouncement"/> cassie announcement to make if the damage kills the player.</param>
+        /// <param name="deathText"> The <see langword="string"/> death text to appear on <see cref="Player"/> screen. </param>
+        public void Hurt(Player attacker, float amount, DamageType damageType = DamageType.Unknown, CassieAnnouncement cassieAnnouncement = null, string deathText = null) =>
+            Hurt(new GenericDamageHandler(this, attacker, amount, damageType, cassieAnnouncement, deathText));
+
+        /// <summary>
+        /// Hurts the player.
+        /// </summary>
+        /// <param name="attacker">The <see cref="Player"/> attacking player.</param>
         /// <param name="damage">The <see langword="float"/> amount of damage to deal.</param>
         /// <param name="force">The throw force.</param>
         /// <param name="armorPenetration">The armor penetration amount.</param>


### PR DESCRIPTION
## Description
**Describe the changes** 
Removes an unnecessary Hurt method overload and introduces a new configurable behavior for Cassie announcements triggered by player deaths.

**What is the current behavior?** (You can also link to an open issue here)
Cassie announcements are triggered on any player death . Additionally, the Hurt method had two overloads, which was unnecessary and potentially confusing. Also, there was no way to override Cassie behavior per Hurt call.

**What is the new behavior?** (if this is a feature change)
Developers can now choose to annoucment Cassie messages for non SCPs by setting overrideCassieForAllRole to true. Only one clean, flexible overload of Hurt remains, simplifying the API surface and supporting all use cases via optional parameters.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, all changes maintain full backward compatibility

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
