### PR TITLE
fix: RemainingDecontaminationTime is wrong

### DIFF
--- a/EXILED/Exiled.API/Features/Map.cs
+++ b/EXILED/Exiled.API/Features/Map.cs
@@ -67,7 +67,7 @@ namespace Exiled.API.Features
         /// <returns>
         /// The remaining time in seconds for the decontamination process.
         /// </returns>
-        public static float RemainingDecontaminationTime => Mathf.Min(0, (float)(DecontaminationController.Singleton.DecontaminationPhases[DecontaminationController.Singleton.DecontaminationPhases.Length - 1].TimeTrigger - DecontaminationController.GetServerTime));
+        public static float RemainingDecontaminationTime => Mathf.Max(0, (float)(DecontaminationController.Singleton.DecontaminationPhases[DecontaminationController.Singleton.DecontaminationPhases.Length - 1].TimeTrigger - DecontaminationController.GetServerTime));
 
         /// <summary>
         /// Gets all <see cref="PocketDimensionTeleport"/> objects.


### PR DESCRIPTION
## Description
**Describe the changes** 
This PR fixes a bug in RemainingDecontaminationTime calculation. It incorrectly used Mathf.Min instead of Mathf.Max, causing the property to always return 0.

**What is the current behavior?** (You can also link to an open issue here)
RemainingDecontaminationTime consistently returns 0 due to Mathf.Min(0, ...) being used.

**What is the new behavior?** (if this is a feature change)
RemainingDecontaminationTime now correctly returns the positive remaining time by using Mathf.Max(0, ...) to ensure accurate duration display.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None. This is a bug fix correcting existing behavior.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
