### PR TITLE
fix: bug with not tracking limit of spawned players in custom roles

### DIFF
--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -924,7 +924,7 @@ namespace Exiled.CustomRoles.API.Features
 
         private void OnInternalSpawned(SpawnedEventArgs ev)
         {
-            if (!IgnoreSpawnSystem && SpawnChance > 0 && !Check(ev.Player) && ev.Player.Role.Type == Role && Loader.Random.NextDouble() * 100 <= SpawnChance)
+            if (!IgnoreSpawnSystem && SpawnChance > 0 && !Check(ev.Player) && ev.Player.Role.Type == Role && Loader.Random.NextDouble() * 100 <= SpawnChance && (SpawnProperties.Limit == 0 || TrackedPlayers.Count < SpawnProperties.Limit))
                 AddRole(ev.Player);
         }
 


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes bug with custom roles spawn system

**What is the current behavior?** (You can also link to an open issue here)
ignores limit for spawn

**What is the new behavior?** (if this is a feature change)
do not give custom role if limit was reached

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
