### PR TITLE
fix: Escaping Exiled and LabAPI bug different way

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Player/EscapingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/EscapingEventArgs.cs
@@ -39,7 +39,7 @@ namespace Exiled.Events.EventArgs.Player
             Player = Player.Get(referenceHub);
             NewRole = newRole;
             EscapeScenario = escapeScenario;
-            IsAllowed = escapeScenario is not EscapeScenario.None and not EscapeScenario.CustomEscape;
+            IsAllowed = escapeScenario is not EscapeScenario.None;
         }
 
         /// <summary>

--- a/EXILED/Exiled.Events/Patches/Events/Player/EscapingAndEscaped.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/EscapingAndEscaped.cs
@@ -13,14 +13,13 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    using API.Enums;
     using API.Features;
     using API.Features.Pools;
     using EventArgs.Player;
     using Exiled.API.Features.Roles;
     using Exiled.Events.Attributes;
     using HarmonyLib;
-    using PlayerRoles.FirstPersonControl;
+    using LabApi.Events.Arguments.PlayerEvents;
 
     using static HarmonyLib.AccessTools;
 
@@ -41,8 +40,8 @@ namespace Exiled.Events.Patches.Events.Player
             LocalBuilder ev = generator.DeclareLocal(typeof(EscapingEventArgs));
             LocalBuilder role = generator.DeclareLocal(typeof(Role));
 
-            int offset = -3;
-            int index = newInstructions.FindIndex(instruction => instruction.opcode == OpCodes.Newobj) + offset;
+            int offset = 2;
+            int index = newInstructions.FindIndex(i => i.opcode == OpCodes.Callvirt && i.operand == (object)PropertyGetter(typeof(PlayerEscapingEventArgs), nameof(PlayerEscapingEventArgs.EscapeScenario))) + offset;
 
             newInstructions.InsertRange(
                 index,


### PR DESCRIPTION
## Description
**Describe the changes** 
Exiled Broken Labapi event fix different way

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)
Because the previous fix broke the custom item escape handler or other conditions that check isallowed. Instead, I brought isallowed to normally return false and not break labapi. Now it comes after exiled labapi, and if isallowed is not true, it can return without breaking labapi.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
