### PR TITLE
feat: add IsOptedOutOfScp getter to Player class

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -677,7 +677,7 @@ namespace Exiled.API.Features
         public bool IsScp => Role?.Type.IsScp() ?? false;
 
         /// <summary>
-        /// Gets Indicates whether the player has enabled the "Opt out of SCP" setting, which prevents them from being assigned any SCP role.
+        /// Gets a value indicating whether the player has enabled the "Opt out of SCP" setting, which prevents them from being assigned any SCP role.
         /// 
         public bool IsOptedOutOfScp => ScpPlayerPicker.IsOptedOutOfScp(ReferenceHub);
 


### PR DESCRIPTION
## Description
**Describe the changes** 
add IsOptedOutOfScp getter for checking if player has opt out of scp enabled

**What is the current behavior?**
You need to use the ScpPlayerPicker class from the Assembly to check if a player is opted out

**What is the new behavior?**
You can directly check if a player is opted out in the Exiled.API.Features.Player class with IsOptedOutOfScp

**Does this PR introduce a breaking change?**
No


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
