### PR TITLE
fix: Custom Scp127 clipsizes causing desyncs

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -17,7 +17,6 @@ namespace Exiled.CustomItems.API.Features
     using Exiled.API.Features.Items;
     using Exiled.API.Features.Pickups;
     using Exiled.Events.EventArgs.Player;
-    using InventorySystem;
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Firearms.Attachments.Components;
     using InventorySystem.Items.Firearms.Modules;
@@ -214,7 +213,7 @@ namespace Exiled.CustomItems.API.Features
             if (!Check(ev.Player.CurrentItem))
                 return;
 
-            if (ClipSize > 0 && ev.Firearm.Base.GetTotalStoredAmmo() >= ClipSize)
+            if (ClipSize > 0 && ev.Firearm.TotalAmmo >= ClipSize)
             {
                 ev.IsAllowed = false;
                 return;
@@ -241,7 +240,7 @@ namespace Exiled.CustomItems.API.Features
                 if (ammoToGive < ammoInInventory)
                 {
                     ev.Firearm.MagazineAmmo = ammoToGive;
-                    int newAmmo = ev.Player.Inventory.GetCurAmmo(ammoType.GetItemType()) + ammoDrop;
+                    int newAmmo = ev.Player.GetAmmo(ammoType) + ammoDrop;
                     ev.Player.SetAmmo(ammoType, (ushort)newAmmo);
                 }
                 else

--- a/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomWeapon.cs
@@ -230,7 +230,7 @@ namespace Exiled.CustomItems.API.Features
 
             if (ClipSize > 0)
             {
-                int ammoChambered = ((AutomaticActionModule)ev.Firearm.Base.Modules.FirstOrDefault(x => x is AutomaticActionModule))?.SyncAmmoChambered ?? 0;
+                int ammoChambered = ((AutomaticActionModule?)ev.Firearm.Base.Modules.FirstOrDefault(x => x is AutomaticActionModule))?.SyncAmmoChambered ?? 0;
                 int ammoToGive = ClipSize - ammoChambered;
 
                 AmmoType ammoType = ev.Firearm.AmmoType;
@@ -242,12 +242,12 @@ namespace Exiled.CustomItems.API.Features
                 {
                     ev.Firearm.MagazineAmmo = ammoToGive;
                     int newAmmo = ev.Player.Inventory.GetCurAmmo(ammoType.GetItemType()) + ammoDrop;
-                    ev.Player.Inventory.ServerSetAmmo(ammoType.GetItemType(), newAmmo);
+                    ev.Player.SetAmmo(ammoType, (ushort)newAmmo);
                 }
                 else
                 {
                     ev.Firearm.MagazineAmmo = ammoInInventory;
-                    ev.Player.Inventory.ServerSetAmmo(ammoType.GetItemType(), 0);
+                    ev.Player.SetAmmo(ammoType, 0);
                 }
             }
 


### PR DESCRIPTION
## Description
**Describe the changes** 
I fixed a small nullability issue then changed the methods directly using base game SetAmmo methods to use Exileds methods (which check the AmmoType to be valid)

**What is the current behavior?** (You can also link to an open issue here)
Scp 127's AmmoType is 255 for exiled cuz NW never added an official ammo for 127. Because of this, when a Custom Weapon 127 reloads and calls OnInternalReloaded, it would do ev.Player.Inventory.ServerSetAmmo(args); and cause the client to desync because the use AmmoType was None

**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
Why didn't Ttrouble just use ev.Player.SetAmmo 😭 
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
