### PR TITLE
fix: Firearm pickups spawning without ammo

### DIFF
--- a/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
+++ b/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
@@ -157,6 +157,7 @@ namespace Exiled.API.Features.Pickups
                 return;
             }
 
+            Ammo = magazine.AmmoMax;
             MaxAmmo = magazine.AmmoMax;
         }
     }


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes a bug where firearm pickups spawned in had no ammo

**What is the current behavior?** (You can also link to an open issue here)
When spawning most firearms, they don't have any ammo inside of them

**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
Appears to work with revolvers and shotguns too
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
