### PR TITLE
fix: Add Player to TrackedPlayers before setting role

### DIFF
--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -39,6 +39,9 @@ namespace Exiled.CustomRoles.API.Features
     {
         private const float AddRoleDelay = 0.25f;
 
+        // used in AddRole and InternalChangingRole
+        private static bool skipChangingCheck;
+
         private static Dictionary<Type, CustomRole?> typeLookupTable = new();
 
         private static Dictionary<string, CustomRole?> stringLookupTable = new();
@@ -515,19 +518,27 @@ namespace Exiled.CustomRoles.API.Features
 
             if (Role != RoleTypeId.None)
             {
-                if (KeepPositionOnSpawn)
+                try
                 {
-                    if (KeepInventoryOnSpawn)
-                        player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.None);
+                    skipChangingCheck = true;
+                    if (KeepPositionOnSpawn)
+                    {
+                        if (KeepInventoryOnSpawn)
+                            player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.None);
+                        else
+                            player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.AssignInventory);
+                    }
                     else
-                        player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.AssignInventory);
+                    {
+                        if (KeepInventoryOnSpawn && player.IsAlive)
+                            player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.UseSpawnpoint);
+                        else
+                            player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.All);
+                    }
                 }
-                else
+                finally
                 {
-                    if (KeepInventoryOnSpawn && player.IsAlive)
-                        player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.UseSpawnpoint);
-                    else
-                        player.Role.Set(Role, SpawnReason.ForceClass, RoleSpawnFlags.All);
+                    skipChangingCheck = false;
                 }
             }
 
@@ -952,8 +963,10 @@ namespace Exiled.CustomRoles.API.Features
 
         private void OnInternalChangingRole(ChangingRoleEventArgs ev)
         {
-            if (ev.IsAllowed && ev.Reason != SpawnReason.Destroyed && Check(ev.Player) && ((ev.NewRole == RoleTypeId.Spectator && !KeepRoleOnDeath) || (ev.NewRole != RoleTypeId.Spectator && !KeepRoleOnChangingRole)))
+            if (!skipChangingCheck && ev.IsAllowed && ev.Reason != SpawnReason.Destroyed && Check(ev.Player) && ((ev.NewRole == RoleTypeId.Spectator && !KeepRoleOnDeath) || (ev.NewRole != RoleTypeId.Spectator && !KeepRoleOnChangingRole)))
                 RemoveRole(ev.Player);
+            else
+                skipChangingCheck = false;
         }
 
         private void OnSpawningRagdoll(SpawningRagdollEventArgs ev)


### PR DESCRIPTION
## Description
**Describe the changes** 
I changed ordering of when player officially "receives" custom role so using Check() in OnSpawned / OnChangingRole will actually work, I had to make a workaround to avoid the InternalChangingRole event from removing the custom role instantly, but it should work.

**What is the current behavior?** (You can also link to an open issue here)
Check() in a CR doesn't work in OnSpawned when they receive a role

**What is the new behavior?** (if this is a feature change)
Check() will work in OnSpawned and OnChangingRole

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
Yamato said he'd test this so it might not work as I haven't tested it
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
