### PR TITLE
fix: firearms spawning with max ammo after being dropped

### DIFF
--- a/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
+++ b/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
@@ -157,7 +157,6 @@ namespace Exiled.API.Features.Pickups
                 return;
             }
 
-            Ammo = magazine.AmmoMax;
             MaxAmmo = magazine.AmmoMax;
         }
     }

--- a/EXILED/Exiled.API/Features/Pickups/Pickup.cs
+++ b/EXILED/Exiled.API/Features/Pickups/Pickup.cs
@@ -474,36 +474,46 @@ namespace Exiled.API.Features.Pickups
         /// <param name="type">The <see cref="ItemType"/> of the pickup.</param>
         /// <returns>The created <see cref="Pickup"/>.</returns>
         /// <seealso cref="Projectile.Create(Enums.ProjectileType)"/>
-        public static Pickup Create(ItemType type) => type.GetTemplate().PickupDropModel switch
+        public static Pickup Create(ItemType type)
         {
-            Scp244DeployablePickup => new Scp244Pickup(type),
-            BaseAmmoPickup => new AmmoPickup(type),
-            BaseRadioPickup => new RadioPickup(),
-            BaseMicroHIDPickup => new MicroHIDPickup(),
-            TimedGrenadePickup timeGrenade => timeGrenade.NetworkInfo.ItemId switch
+            Pickup p = type.GetTemplate().PickupDropModel switch
             {
-                ItemType.GrenadeHE => new ExplosiveGrenadePickup(),
-                ItemType.GrenadeFlash => new FlashGrenadePickup(),
-                _ => new GrenadePickup(type),
-            },
-            BaseFirearmPickup => new FirearmPickup(type),
-            BaseKeycardPickup => new KeycardPickup(type),
-            BaseBodyArmorPickup => new BodyArmorPickup(type),
-            BaseScp330Pickup => new Scp330Pickup(),
-            BaseScp1576Pickup => new Scp1576Pickup(),
-            BaseJailbirdPickup => new JailbirdPickup(),
-            ThrownProjectile thrownProjectile => thrownProjectile switch
+                Scp244DeployablePickup => new Scp244Pickup(type),
+                BaseAmmoPickup => new AmmoPickup(type),
+                BaseRadioPickup => new RadioPickup(),
+                BaseMicroHIDPickup => new MicroHIDPickup(),
+                TimedGrenadePickup timeGrenade => timeGrenade.NetworkInfo.ItemId switch
+                {
+                    ItemType.GrenadeHE => new ExplosiveGrenadePickup(),
+                    ItemType.GrenadeFlash => new FlashGrenadePickup(),
+                    _ => new GrenadePickup(type),
+                },
+                BaseFirearmPickup => new FirearmPickup(type),
+                BaseKeycardPickup => new KeycardPickup(type),
+                BaseBodyArmorPickup => new BodyArmorPickup(type),
+                BaseScp330Pickup => new Scp330Pickup(),
+                BaseScp1576Pickup => new Scp1576Pickup(),
+                BaseJailbirdPickup => new JailbirdPickup(),
+                ThrownProjectile thrownProjectile => thrownProjectile switch
+                {
+                    BaseScp018Projectile => new Projectiles.Scp018Projectile(),
+                    ExplosionGrenade explosionGrenade => new ExplosionGrenadeProjectile(type),
+                    FlashbangGrenade => new FlashbangProjectile(),
+                    BaseScp2176Projectile => new Projectiles.Scp2176Projectile(),
+                    EffectGrenade => new EffectGrenadeProjectile(type),
+                    TimeGrenade => new TimeGrenadeProjectile(type),
+                    _ => new Projectile(type),
+                },
+                _ => new Pickup(type),
+            };
+
+            if (p is FirearmPickup firearm)
             {
-                BaseScp018Projectile => new Projectiles.Scp018Projectile(),
-                ExplosionGrenade explosionGrenade => new ExplosionGrenadeProjectile(type),
-                FlashbangGrenade => new FlashbangProjectile(),
-                BaseScp2176Projectile => new Projectiles.Scp2176Projectile(),
-                EffectGrenade => new EffectGrenadeProjectile(type),
-                TimeGrenade => new TimeGrenadeProjectile(type),
-                _ => new Projectile(type),
-            },
-            _ => new Pickup(type),
-        };
+                firearm.Ammo = firearm.MaxAmmo;
+            }
+
+            return p;
+        }
 
         /// <summary>
         /// Creates and returns a new <see cref="Pickup"/> with the proper inherited subclass.


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes bug

**What is the current behavior?** (You can also link to an open issue here)
All dropped guns spawn with max ammo, regardless of how much they should have

**What is the new behavior?** (if this is a feature change)
Only newly spawned guns spawned directly from Pickup.Create get max ammo

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
I have made a severe and continuous lapse in my judgement (I made PR that caused the bug)
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
