### PR TITLE
feat: add `Player.Enumerable` and `Player.Count` properties

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -139,6 +139,19 @@ namespace Exiled.API.Features
         public static IReadOnlyCollection<Player> List => Dictionary.Values.ToList();
 
         /// <summary>
+        /// Gets an <see cref="IEnumerable{T}"/> of all <see cref="Player"/>'s on the server.
+        /// This property should be used for enumeration (e.g. LINQ) as it doesn't create a new list, improving performance.
+        /// </summary>
+        public static IEnumerable<Player> Enumerable => Dictionary.Values;
+
+        /// <summary>
+        /// Gets the number of players currently on the server.
+        /// </summary>
+        /// <seealso cref="List"/>
+        /// <seealso cref="Enumerable"/>
+        public static int Count => Dictionary.Count;
+
+        /// <summary>
         /// Gets a <see cref="Dictionary{TKey, TValue}"/> containing cached <see cref="Player"/> and their user ids.
         /// </summary>
         public static Dictionary<string, Player> UserIdsCache { get; } = new(20);

--- a/EXILED/Exiled.API/Features/Server.cs
+++ b/EXILED/Exiled.API/Features/Server.cs
@@ -143,11 +143,8 @@ namespace Exiled.API.Features
             }
         }
 
-        /// <summary>
-        /// Gets the number of players currently on the server.
-        /// </summary>
-        /// <seealso cref="Player.List"/>
-        public static int PlayerCount => Player.Dictionary.Count;
+        /// <inheritdoc cref="Player.Count"/>
+        public static int PlayerCount => Player.Count;
 
         /// <summary>
         /// Gets or sets the maximum number of players able to be on the server.


### PR DESCRIPTION
## Description
Add two properties `Player.Enumerable` and `Player.Count`. First one is useful for optimizing LINQ calls to `Player.List` by avoiding creating new lists. Second one will promote not creating new lists for simple operations such as `Player.List.Count` - which currently first copies all players to a new list, not all people know to use `Player.Dictionary.Count`.

**Does this PR introduce a breaking change?**
No breaking changes

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
