### PR TITLE
fix: CheaterReport.SubmitReport not working

### DIFF
--- a/EXILED/Exiled.Events/Patches/Fixes/CheaterReportFix.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/CheaterReportFix.cs
@@ -1,0 +1,53 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CheaterReportFix.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+    using Exiled.API.Features.Pools;
+
+    using HarmonyLib;
+
+    /// <summary>
+    /// Patches <see cref="CheaterReport.SubmitReport"/>.
+    /// Fixes method not working.
+    /// Bug reported to NW (https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/1814).
+    /// </summary>
+    [HarmonyPatch(typeof(CheaterReport), nameof(CheaterReport.SubmitReport))]
+    public class CheaterReportFix
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            CodeInstruction instruction = newInstructions.Find(instruction => instruction.opcode == OpCodes.Ldstr);
+
+            // will notify devs of fix when NW fixes themselves, rather than another silent error
+            if (instruction.operand is not "payload_json=")
+            {
+                Log.Error($"{typeof(CheaterReportFix).FullName} failed to fix {typeof(CheaterReport).FullName}.{nameof(CheaterReport.SubmitReport)}, please verify this fix is still required and fix it if so.");
+
+                for (int index = 0; index < newInstructions.Count; index++)
+                    yield return newInstructions[index];
+
+                ListPool<CodeInstruction>.Pool.Return(newInstructions);
+                yield break;
+            }
+
+            // easiest solution with minimal changes, but NW fixing it will make us cause issue.
+            instruction.operand = string.Empty;
+
+            for (int index = 0; index < newInstructions.Count; index++)
+                yield return newInstructions[index];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+}


### PR DESCRIPTION
## Description
**Describe the changes** 
Made a transpiler to fix a broken method cuz of NW

**What is the current behavior?** (You can also link to an open issue here)
method doesnt work. https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/1814

**What is the new behavior?** (if this is a feature change)
method works

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
If NW fixes this, my transpiler should print an error indicating that the transpiler needs to be fixed or is obsolete
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
