### PR TITLE
refactor: rewrite CustomScpTermination

### DIFF
--- a/EXILED/Exiled.API/Features/Cassie.cs
+++ b/EXILED/Exiled.API/Features/Cassie.cs
@@ -151,34 +151,23 @@ namespace Exiled.API.Features
             string result = "SCP " + scpNumber;
             if (info.Attacker is null)
             {
-                if (info.Type is Enums.DamageType.Warhead)
-                    result += " SUCCESSFULLY TERMINATED BY ALPHA WARHEAD";
-                else if (info.Type is Enums.DamageType.Decontamination)
-                    result += " LOST IN DECONTAMINATION SEQUENCE";
-                else if (info.Type is Enums.DamageType.Tesla)
-                    result += " SUCCESSFULLY TERMINATED BY AUTOMATIC SECURITY SYSTEM";
-                else
-                    result += " SUCCESSFULLY TERMINATED . TERMINATION CAUSE UNSPECIFIED";
+                result += info.Type switch
+                {
+                    Enums.DamageType.Warhead => " SUCCESSFULLY TERMINATED BY ALPHA WARHEAD",
+                    Enums.DamageType.Decontamination => " LOST IN DECONTAMINATION SEQUENCE",
+                    Enums.DamageType.Tesla => " SUCCESSFULLY TERMINATED BY AUTOMATIC SECURITY SYSTEM",
+                    _ => " SUCCESSFULLY TERMINATED . TERMINATION CAUSE UNSPECIFIED",
+                };
             }
             else
             {
-                if (info.Attacker.Role.Team is Team.SCPs)
+                result += info.Attacker.Role.Team switch
                 {
-                    string attacker_name = string.Join(" ", info.Attacker.Role.Name.Remove(0, 4).ToCharArray());
-                    result += " TERMINATED BY SCP " + attacker_name;
-                }
-                else if (info.Attacker.Role.Team is Team.Flamingos)
-                {
-                    result += " TERMINATED BY SCP 1 5 0 7";
-                }
-                else if (info.Attacker.Role.Team is Team.OtherAlive || info.Attacker.Role.Team is Team.Dead)
-                {
-                    result += " SUCCESSFULLY TERMINATED . TERMINATION CAUSE UNSPECIFIED";
-                }
-                else
-                {
-                    result += " CONTAINEDSUCCESSFULLY " + ConvertTeam(info.Attacker.Role.Team, info.Attacker.UnitName);
-                }
+                    Team.SCPs => " TERMINATED BY SCP " + string.Join(" ", info.Attacker.Role.Name.Remove(0, 4).ToCharArray()),
+                    Team.Flamingos => " TERMINATED BY SCP 1 5 0 7",
+                    Team.OtherAlive or Team.Dead => " SUCCESSFULLY TERMINATED . TERMINATION CAUSE UNSPECIFIED",
+                    _ => " CONTAINEDSUCCESSFULLY " + ConvertTeam(info.Attacker.Role.Team, info.Attacker.UnitName),
+                };
             }
 
             float num = AlphaWarheadController.TimeUntilDetonation <= 0f ? 3.5f : 1f;


### PR DESCRIPTION
Refine and match corresponding DamageHandler

## Description
**Describe the changes** 
Refactored CustomScpTermination to align with the new CustomHandler type and DamageType enumeration, removed overly-restrictive CustomHandlerBase type checks, filled in all missing kill scenarios.

**What is the current behavior?** (You can also link to an open issue here)
- Missing messages for Scp Kill Scp, SCP-1507, and unknown death reason
- Potential NullReferenceException
- Messages do not match the actual DamageHandler(eg. MicroHidDamageHandler -> "TERMINATED BY AUTOMATIC SECURITY SYSTEM")

**What is the new behavior?** (if this is a feature change)
- Uses CustomDamageHandler exclusively; determines kill source via DamageType and Attacker
- Adds new text branches for Scp Kill Scp, SCP-1507, and unspecified kills
- Explicit null-check for info and Attacker to prevent exceptions

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- [x] Yes — method signature changed from CustomHandlerBase to CustomHandler; any external callers must update their references.
(Impact is zero if the entire codebase already uses CustomHandler.)

**Other information**:
- Glitchy effect parameters (GlitchyMessage glitchChance/jamChance) remain unchanged
- No Harmony patches or IL modifications required
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
