### PR TITLE
feat: more CustomRole and CustomAbility register methods that dont rely on attribute

### DIFF
--- a/EXILED/Exiled.CustomRoles/API/Features/CustomAbility.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomAbility.cs
@@ -106,6 +106,37 @@ namespace Exiled.CustomRoles.API.Features
         /// <summary>
         /// Registers all the <see cref="CustomAbility"/>'s present in the current assembly.
         /// </summary>
+        /// <param name="byAttribute">Whether to register by attribute.</param>
+        /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="CustomAbility"/> which contains all registered <see cref="CustomAbility"/>'s.</returns>
+        /// <remarks>
+        /// This is just a dumbed down version of <see cref="RegisterAbilities(bool, object?)"/> for QoL, if you actually use <see cref="CustomAbilityAttribute"/>, do not use this overload.
+        /// </remarks>
+        public static IEnumerable<CustomAbility> RegisterAbilities(bool byAttribute = false)
+        {
+            if (byAttribute)
+            {
+                return RegisterAbilities(false, null);
+            }
+
+            List<CustomAbility> abilities = new();
+
+            foreach (Type type in Assembly.GetCallingAssembly().GetTypes())
+            {
+                if (type.IsAbstract || !type.IsSubclassOf(typeof(CustomAbility)))
+                    continue;
+
+                CustomAbility ability = (CustomAbility)Activator.CreateInstance(type);
+
+                if (ability.TryRegister())
+                    abilities.Add(ability);
+            }
+
+            return abilities;
+        }
+
+        /// <summary>
+        /// Registers all the <see cref="CustomAbility"/>'s present in the current assembly.
+        /// </summary>
         /// <param name="skipReflection">Whether reflection is skipped (more efficient if you are not using your custom item classes as config objects).</param>
         /// <param name="overrideClass">The class to search properties for, if different from the plugin's config class.</param>
         /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="CustomAbility"/> which contains all registered <see cref="CustomAbility"/>'s.</returns>

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -290,6 +290,37 @@ namespace Exiled.CustomRoles.API.Features
         /// <summary>
         /// Registers all the <see cref="CustomRole"/>'s present in the current assembly.
         /// </summary>
+        /// <param name="byAttribute">Whether to register by attribute.</param>
+        /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="CustomRole"/> which contains all registered <see cref="CustomRole"/>'s.</returns>
+        /// <remarks>
+        /// This is just a dumbed down version of <see cref="RegisterRoles(bool, object?)"/> for QoL, if you actually use <see cref="CustomRoleAttribute"/>, do not use this overload.
+        /// </remarks>
+        public static IEnumerable<CustomRole> RegisterRoles(bool byAttribute = false)
+        {
+            if (byAttribute)
+            {
+                return RegisterRoles(false, null);
+            }
+
+            List<CustomRole> roles = new();
+
+            foreach (Type type in Assembly.GetCallingAssembly().GetTypes())
+            {
+                if (type.IsAbstract || !type.IsSubclassOf(typeof(CustomRole)))
+                    continue;
+
+                CustomRole role = (CustomRole)Activator.CreateInstance(type);
+
+                if (role.TryRegister())
+                    roles.Add(role);
+            }
+
+            return roles;
+        }
+
+        /// <summary>
+        /// Registers all the <see cref="CustomRole"/>'s present in the current assembly.
+        /// </summary>
         /// <param name="skipReflection">Whether reflection is skipped (more efficient if you are not using your custom item classes as config objects).</param>
         /// <param name="overrideClass">The class to search properties for, if different from the plugin's config class.</param>
         /// <returns>A <see cref="IEnumerable{T}"/> of <see cref="CustomRole"/> which contains all registered <see cref="CustomRole"/>'s.</returns>


### PR DESCRIPTION
## Description
**Describe the changes** 
Some people were complaining CustomRole.RegisterRoles(); and CustomAbility.RegisterAbilities(); didnt work (mostly cuz they didnt have the respective attribute) but considering these people dont really expect to use them, I feel like I might as well just add a really simple register method.

**What is the current behavior?** (You can also link to an open issue here)
You MUST use attributes to use Exiled register methods

**What is the new behavior?** (if this is a feature change)
You can use new methods to register all classes that derive from CustomRole / CustomAbility (and arent abstract)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Don't believe so

**Other information**:
Haven't tested, I @'d someone on discord to hopefully get them to test it themselves, but you guys can provide any thoughts you want here while we wait.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
