### PR TITLE
fix: Falling into the void at the Pocket Dimension exit

### DIFF
--- a/EXILED/Exiled.Events/Patches/Fixes/FixCapturePosition.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/FixCapturePosition.cs
@@ -24,7 +24,7 @@ namespace Exiled.Events.Patches.Fixes
         private const RoomType DefaultRoomType = RoomType.Surface;
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
-        private static void Postfix(PocketCorroding __instance, ref RelativePosition __result)
+        private static void Postfix(ref RelativePosition __result)
         {
             if (__result.Position != Vector3.zero)
                 return;

--- a/EXILED/Exiled.Events/Patches/Fixes/FixCapturePosition.cs
+++ b/EXILED/Exiled.Events/Patches/Fixes/FixCapturePosition.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------
+// <copyright file="FixCapturePosition.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Fixes
+{
+    using CustomPlayerEffects;
+    using Exiled.API.Enums;
+    using Exiled.API.Features;
+    using HarmonyLib;
+    using RelativePositioning;
+    using UnityEngine;
+
+    /// <summary>
+    /// Patches <see cref="PocketCorroding.CapturePosition" />'s setter.
+    /// Fix for those who go to pocket without effect and to get empty or null capture position and fall into the void.
+    /// </summary>
+    [HarmonyPatch(typeof(PocketCorroding), nameof(PocketCorroding.CapturePosition), MethodType.Getter)]
+    internal class FixCapturePosition
+    {
+        private const RoomType DefaultRoomType = RoomType.Surface;
+
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+        private static void Postfix(PocketCorroding __instance, ref RelativePosition __result)
+        {
+            if (__result.Position != Vector3.zero)
+                return;
+
+            Room room = Room.Get(DefaultRoomType);
+            __result = new RelativePosition(room.Position);
+        }
+    }
+}


### PR DESCRIPTION
## Description
**Describe the changes** 
Falling into the void at the Pocket Dimension exit

**What is the current behavior?** (You can also link to an open issue here)
If you went to the pocket dimension by teleportation or displacement, you would fall into the void.

**What is the new behavior?** (if this is a feature change)
If the position is invalid, a safe position is returned

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
