### PR TITLE
fix: Cassie fixes

### DIFF
--- a/EXILED/Exiled.API/Features/DamageHandlers/DamageHandlerBase.cs
+++ b/EXILED/Exiled.API/Features/DamageHandlers/DamageHandlerBase.cs
@@ -289,7 +289,7 @@ namespace Exiled.API.Features.DamageHandlers
                 new()
                 {
                     Announcement = cassieAnnouncement.Announcement,
-                    SubtitleParts = cassieAnnouncement.SubtitleParts.ToArray(),
+                    SubtitleParts = cassieAnnouncement.SubtitleParts?.ToArray() ?? Array.Empty<Subtitles.SubtitlePart>(),
                 };
 
             /// <summary>

--- a/EXILED/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
+++ b/EXILED/Exiled.API/Features/DamageHandlers/GenericDamageHandler.cs
@@ -234,6 +234,11 @@ namespace Exiled.API.Features.DamageHandlers
         public PlayerStatsSystem.DamageHandlerBase Base { get; set; }
 
         /// <summary>
+        /// Gets the <see cref="PlayerStatsSystem.DamageHandlerBase.CassieAnnouncement"/> the base game uses when a player dies.
+        /// </summary>
+        public override CassieAnnouncement CassieDeathAnnouncement => customCassieAnnouncement;
+
+        /// <summary>
         /// Gets or sets the current attacker.
         /// </summary>
         public Footprint Attacker { get; set; }


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixed AnnouncingNtfEntrance and AnnouncingChaosEntrance showing subtitles when event was denied, as well as GenericDamageHandler throwing NRE in LabAPI ServerEvents.OnCassieQueuingScpTermination from CassieAnnouncement when no subtitles were provided to the ctor

**What is the current behavior?** (You can also link to an open issue here)
A few issues

**What is the new behavior?** (if this is a feature change)
Less issues

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

**Other information**:
Overriding CassieDeathAnnouncement might break stuff, but I can't figure out any cases where that'd happen (nor have I seen Cassie behaving weird)
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
