### PR TITLE
fix: EscapingEventArgs::IsAllowed forces escape

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Player/EscapingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Player/EscapingEventArgs.cs
@@ -7,21 +7,19 @@
 
 namespace Exiled.Events.EventArgs.Player
 {
-    using System.Collections.Generic;
-
     using API.Features;
     using Exiled.API.Enums;
     using Interfaces;
 
     using PlayerRoles;
 
-    using Respawning;
-
     /// <summary>
     /// Contains all information before a player escapes.
     /// </summary>
     public class EscapingEventArgs : IPlayerEvent, IDeniableEvent
     {
+        private EscapeScenario escapeScenario;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EscapingEventArgs" /> class.
         /// </summary>
@@ -55,7 +53,11 @@ namespace Exiled.Events.EventArgs.Player
         /// <summary>
         /// Gets or sets the EscapeScenario that will represent for this player.
         /// </summary>
-        public EscapeScenario EscapeScenario { get; set; }
+        public EscapeScenario EscapeScenario
+        {
+            get => (escapeScenario is EscapeScenario.None && IsAllowed) ? EscapeScenario.CustomEscape : escapeScenario;
+            set => escapeScenario = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the player can escape.


### PR DESCRIPTION
## Description
**Describe the changes** 
see title

**What is the current behavior?** (You can also link to an open issue here)
You have to set ev.EscapeScenario to force an escape

**What is the new behavior?** (if this is a feature change)
IsAllowed will force an escape (but it also respects custom escape reasons)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No? I was told this behavior was the norm prior to this beta

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
