### PR TITLE
fix: group(rank) and renaming of some properties

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -564,7 +564,11 @@ namespace Exiled.API.Features
         public PlayerPermissions RemoteAdminPermissions
         {
             get => (PlayerPermissions)ReferenceHub.serverRoles.Permissions;
-            set => ReferenceHub.serverRoles.Permissions = (ulong)value;
+            set
+            {
+                ReferenceHub.serverRoles.Permissions = (ulong)value;
+                ReferenceHub.serverRoles.FinalizeSetGroup();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Bug fixes and renaming of some properties to more understandable ones. We need to test this to make sure it doesn't cause problems, because God only knows how it all works internally.

**What is the current behavior?** (You can also link to an open issue here)
- bug: https://discord.com/channels/656673194693885975/1002713309876854924/1432873468285948055

**What is the new behavior?** (if this is a feature change)
- Now the SetGroup method of Player either finds an existing group and assigns it to the player, or creates a group based on UserGroup and also assigns it to the player. This method was also renamed to SetGroup.
- The Player's RemoteAdminPermissions property now actually grants rights to the player and instantly determines access to the RA panel and permissions-related functionality.
- Removed the useless setter for the GroupName property of Player.
- Player's RankColor property has been renamed to BadgeColor.
- Player's RankName property has been renamed to BadgeText.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- Various renamings. One useless setter missing.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [x] Still requires more testing
