### PR TITLE
fix: Make GetEffectType not brick server when no key is found

### DIFF
--- a/EXILED/Exiled.API/Extensions/EffectTypeExtension.cs
+++ b/EXILED/Exiled.API/Extensions/EffectTypeExtension.cs
@@ -135,7 +135,7 @@ namespace Exiled.API.Extensions
         {
             if (!TypeToEffectType.TryGetValue(statusEffectBase.GetType(), out EffectType type))
             {
-                Log.Error($"Missing EffectType for Type {statusEffectBase.GetType()}!!! This issue likely originates from a new update, please fix!");
+                Log.Warn($"Missing EffectType for Type {statusEffectBase.GetType()}!!! This issue likely originates from a new update or a CustomEffect on your Server");
                 return EffectType.None;
             }
 


### PR DESCRIPTION
## Description
**Describe the changes** 
see title

**What is the current behavior?** (You can also link to an open issue here)
If new EffectType is missing, is very annoying to debug

**What is the new behavior?** (if this is a feature change)
Now you get spam of what missing effect is, other weird stuff might happen, dunno, but you'd def know what went wrong

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
