### PR TITLE
feat: TrySetRank method(and refactor)

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -1935,10 +1935,24 @@ namespace Exiled.API.Features
                 ReferenceHub.serverRoles.SetGroup(group, false, false);
             }
 
-            if (ServerStatic.PermissionsHandler.Members.ContainsKey(UserId))
+            ServerStatic.PermissionsHandler.Members[UserId] = name;
+        }
+
+        /// <summary>
+        /// If the rank(group) exists in the remote admin config, it will assign it to the player.
+        /// </summary>
+        /// <param name="name">The rank name to be set.</param>
+        /// <returns><see langword="true"/> if the rank(group) was found and successfully assigned, <see langword="false"/> otherwise.</returns>
+        public bool TrySetRank(string name)
+        {
+            if (ServerStatic.PermissionsHandler.Groups.TryGetValue(name, out UserGroup userGroup))
+            {
+                ReferenceHub.serverRoles.SetGroup(userGroup, false, false);
                 ServerStatic.PermissionsHandler.Members[UserId] = name;
-            else
-                ServerStatic.PermissionsHandler.Members.Add(UserId, name);
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## feat: TrySetRank method(and refactor)
**Describe the changes** 
New TrySetRank method. Refactoring of the SetRank method.

**What is the current behavior?** (You can also link to an open issue here)
Unfortunately, the standard SetRank method requires creating a UserGroup object, which isn't always convenient. Specifying "null" isn't always a good idea, and it doesn't meet the requirements for clean and correct code. Furthermore, it's not entirely clear what happens if you specify null.
https://discord.com/channels/656673194693885975/1002713309876854924/1436117402965508147

**What is the new behavior?** (if this is a feature change)
It has become convenient to assign a rank (group).

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled(An error related to "RelativeBounds" prevented the compilation, but I didn't create this error.)
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
