### PR TITLE
fix: AdminToy.Position & Rotation ignoring parenting

### DIFF
--- a/EXILED/Exiled.API/Features/Toys/AdminToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/AdminToy.cs
@@ -79,11 +79,11 @@ namespace Exiled.API.Features.Toys
         /// </summary>
         public Vector3 Position
         {
-            get => AdminToyBase.transform.position;
+            get => Transform.position;
             set
             {
-                AdminToyBase.transform.position = value;
-                AdminToyBase.NetworkPosition = value;
+                Transform.position = value;
+                AdminToyBase.NetworkPosition = Transform.localPosition;
             }
         }
 
@@ -92,11 +92,11 @@ namespace Exiled.API.Features.Toys
         /// </summary>
         public Quaternion Rotation
         {
-            get => AdminToyBase.transform.rotation;
+            get => Transform.rotation;
             set
             {
-                AdminToyBase.transform.rotation = value;
-                AdminToyBase.NetworkRotation = value;
+                Transform.rotation = value;
+                AdminToyBase.NetworkRotation = Transform.localRotation;
             }
         }
 
@@ -105,10 +105,10 @@ namespace Exiled.API.Features.Toys
         /// </summary>
         public Vector3 Scale
         {
-            get => AdminToyBase.transform.localScale;
+            get => Transform.localScale;
             set
             {
-                AdminToyBase.transform.localScale = value;
+                Transform.localScale = value;
                 AdminToyBase.NetworkScale = value;
             }
         }


### PR DESCRIPTION
## Description
**Describe the changes** 
NetworkPosition and NetworkRotation syncvars control local position/rotation, but Exiled AdminToy's properties were assigning global values to them.

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
