### PR TITLE
fix: Cassie.CalculateDuration

### DIFF
--- a/EXILED/Exiled.API/Features/Cassie.cs
+++ b/EXILED/Exiled.API/Features/Cassie.cs
@@ -106,7 +106,7 @@ namespace Exiled.API.Features
         /// <param name="obsolete1">An obsolete parameter.</param>
         /// <param name="obsolete2">Another obsolete parameter.</param>
         /// <returns>Duration (in seconds) of specified message.</returns>
-        public static float CalculateDuration(string message, bool obsolete1, float obsolete2)
+        public static float CalculateDuration(string message, bool obsolete1 = false, float obsolete2 = 0f)
         {
             if (!CassieTtsAnnouncer.TryGetDatabase(out CassieLineDatabase cassieLineDatabase))
             {


### PR DESCRIPTION
## Description
**Describe the changes** 
A new Cassie feature.CalculateDuration requires you to specify outdated parameters that were previously optional.

**What is the current behavior?** (You can also link to an open issue here)
`Cassie.CalculateDuration` requires you to specify obsolete parameters

**What is the new behavior?** (if this is a feature change)
Obsolete parameters are no longer required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
