### PR TITLE
fix: cassie MessageTranslated & replace obsolete "isHeld"

### DIFF
--- a/EXILED/Exiled.API/Features/Cassie.cs
+++ b/EXILED/Exiled.API/Features/Cassie.cs
@@ -47,7 +47,7 @@ namespace Exiled.API.Features
         /// <param name="isNoisy">Indicates whether C.A.S.S.I.E has to make noises during the message.</param>
         /// <param name="isSubtitles">Indicates whether C.A.S.S.I.E has to make subtitles.</param>
         public static void Message(string message, bool isHeld = false, bool isNoisy = true, bool isSubtitles = false) =>
-            new CassieAnnouncement(new CassieTtsPayload(message, isSubtitles, isNoisy), 0f, isNoisy ? 1 : 0).AddToQueue();
+            new CassieAnnouncement(new CassieTtsPayload(message, isSubtitles, isHeld), 0f, isNoisy ? 1 : 0).AddToQueue();
 
         /// <summary>
         /// Reproduce a non-glitched C.A.S.S.I.E message with a possibility to custom the subtitles.
@@ -59,14 +59,7 @@ namespace Exiled.API.Features
         /// <param name="isSubtitles">Indicates whether C.A.S.S.I.E has to make subtitles.</param>
         public static void MessageTranslated(string message, string translation, bool isHeld = false, bool isNoisy = true, bool isSubtitles = true)
         {
-            StringBuilder announcement = StringBuilderPool.Pool.Get();
-            string[] cassies = message.Split('\n');
-            string[] translations = translation.Split('\n');
-            for (int i = 0; i < cassies.Length; i++)
-                announcement.Append($"{translations[i].Replace(' ', ' ')}<size=0> {cassies[i]} </size><split>");
-
-            new CassieAnnouncement(new CassieTtsPayload(message, announcement.ToString(), isNoisy), 0f, isNoisy ? 1 : 0).AddToQueue();
-            StringBuilderPool.Pool.Return(announcement);
+            new CassieAnnouncement(new CassieTtsPayload(message, translation, isHeld), 0f, isNoisy ? 1 : 0).AddToQueue();
         }
 
         /// <summary>
@@ -87,7 +80,7 @@ namespace Exiled.API.Features
         /// <param name="isNoisy">Indicates whether C.A.S.S.I.E has to make noises during the message.</param>
         /// <param name="isSubtitles">Indicates whether C.A.S.S.I.E has to make subtitles.</param>
         public static void DelayedMessage(string message, float delay, bool isHeld = false, bool isNoisy = true, bool isSubtitles = false) =>
-            Timing.CallDelayed(delay, () => new CassieAnnouncement(new CassieTtsPayload(message, isSubtitles, isNoisy), 0f, isNoisy ? 1 : 0).AddToQueue());
+            Timing.CallDelayed(delay, () => new CassieAnnouncement(new CassieTtsPayload(message, isSubtitles, isHeld), 0f, isNoisy ? 1 : 0).AddToQueue());
 
         /// <summary>
         /// Reproduce a glitchy C.A.S.S.I.E announcement after a certain period of seconds.
@@ -106,7 +99,15 @@ namespace Exiled.API.Features
         /// <param name="obsolete1">An obsolete parameter.</param>
         /// <param name="obsolete2">Another obsolete parameter.</param>
         /// <returns>Duration (in seconds) of specified message.</returns>
-        public static float CalculateDuration(string message, bool obsolete1, float obsolete2)
+        [Obsolete("Please use CalculateDuration(string)", true)]
+        public static float CalculateDuration(string message, bool obsolete1, float obsolete2) => CalculateDuration(message);
+
+        /// <summary>
+        /// Calculates the duration of a C.A.S.S.I.E message.
+        /// </summary>
+        /// <param name="message">The message, which duration will be calculated.</param>
+        /// <returns>Duration (in seconds) of specified message.</returns>
+        public static float CalculateDuration(string message)
         {
             if (!CassieTtsAnnouncer.TryGetDatabase(out CassieLineDatabase cassieLineDatabase))
             {


### PR DESCRIPTION
## Description
**Describe the changes** 


**What is the current behavior?** (You can also link to an open issue here)
MessageTranslated uses the wrong payload and therefore does not send subtitles, only the original message. In addition, MessageTranslated & Message uses “isHeld” where it should be isNoisy.

**What is the new behavior?** (if this is a feature change)
MessageTranslated now uses the correct CassieTtsPayload and sends the custom subtitles along with it. isNoisy is used in exactly the right places.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
