### PR TITLE
fix: change release sorting from CreatedAt to Id

### DIFF
--- a/EXILED/Exiled.Installer/Program.cs
+++ b/EXILED/Exiled.Installer/Program.cs
@@ -172,7 +172,7 @@ namespace Exiled.Installer
                     r => Version.TryParse(r.TagName, out Version version)
                          && version > VersionLimit);
 
-            return releases.OrderByDescending(r => r.Id);
+            return releases.OrderByDescending(r => r.PublishedAt);
         }
 
         private static string FormatRelease(Release r)


### PR DESCRIPTION
## Description
**Describe the changes** 
Releases are now sorted by their God (GitHub) given Id in descending order instead of by their creation time.

**What is the current behavior?** (You can also link to an open issue here)

```
[hobby@excitement ~/Downloads] $ ./Exiled.Installer-Linux --get-versions
Exiled.Installer-Linux-4.0.0.0
--- AVAILABLE VERSIONS ---
PRE: False | ID: 270534588 | TAG: v9.11.1  <--- This should NOT be the "newest" release!
   - ID: 329047763 | NAME: Exiled.Installer-Linux | SIZE: 65868504 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329047763 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.1/Exiled.Installer-Linux
   - ID: 329047762 | NAME: Exiled.Installer-Win.exe | SIZE: 64415787 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329047762 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.1/Exiled.Installer-Win.exe
   - ID: 329066981 | NAME: Exiled.tar.gz | SIZE: 1074841 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329066981 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.1/Exiled.tar.gz
PRE: False | ID: 270562189 | TAG: v9.11.2
   - ID: 329082584 | NAME: Exiled.Installer-Linux | SIZE: 65868504 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329082584 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.2/Exiled.Installer-Linux
   - ID: 329082583 | NAME: Exiled.Installer-Win.exe | SIZE: 64415787 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329082583 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.2/Exiled.Installer-Win.exe
   - ID: 329103691 | NAME: Exiled.tar.gz | SIZE: 1074786 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329103691 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.2/Exiled.tar.gz
PRE: False | ID: 270514647 | TAG: v9.11.0
```

**What is the new behavior?** (if this is a feature change)

```
[hobby@excitement ~/Projects/EXILED/EXILED/Exiled.Installer/bin/Debug] $ ./Exiled.Installer --get-versions
Exiled.Installer-4.0.0.0
--- AVAILABLE VERSIONS ---
PRE: False | ID: 270562189 | TAG: v9.11.2  <--- Now THIS is looking correct ^^
   - ID: 329082584 | NAME: Exiled.Installer-Linux | SIZE: 65868504 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329082584 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.2/Exiled.Installer-Linux
   - ID: 329082583 | NAME: Exiled.Installer-Win.exe | SIZE: 64415787 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329082583 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.2/Exiled.Installer-Win.exe
   - ID: 329103691 | NAME: Exiled.tar.gz | SIZE: 1074786 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329103691 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.2/Exiled.tar.gz
PRE: False | ID: 270534588 | TAG: v9.11.1
   - ID: 329047763 | NAME: Exiled.Installer-Linux | SIZE: 65868504 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329047763 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.1/Exiled.Installer-Linux
   - ID: 329047762 | NAME: Exiled.Installer-Win.exe | SIZE: 64415787 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329047762 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.1/Exiled.Installer-Win.exe
   - ID: 329066981 | NAME: Exiled.tar.gz | SIZE: 1074841 | URL: https://api.github.com/repos/ExMod-Team/EXILED/releases/assets/329066981 | DownloadURL: https://github.com/ExMod-Team/EXILED/releases/download/v9.11.1/Exiled.tar.gz
PRE: False | ID: 270514647 | TAG: v9.11.0
```
**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
