### PR TITLE
fix: Fix UsedItem being called twice

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Player/UsedItemByHolstering.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/UsedItemByHolstering.cs
@@ -10,12 +10,14 @@ namespace Exiled.Events.Patches.Events.Player
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
+    using CustomPlayerEffects;
     using Exiled.API.Features;
     using Exiled.API.Features.Pools;
     using Exiled.Events.Attributes;
     using Exiled.Events.EventArgs.Player;
     using HarmonyLib;
     using InventorySystem.Items.Usables;
+    using UnityEngine;
 
     using static HarmonyLib.AccessTools;
 
@@ -27,13 +29,56 @@ namespace Exiled.Events.Patches.Events.Player
     [HarmonyPatch(typeof(Consumable), nameof(Consumable.OnHolstered))]
     public class UsedItemByHolstering
     {
-        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
         {
             List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
 
-            // after ServerRemoveSelf, which lines up with before the ret
-            newInstructions.InsertRange(newInstructions.Count - 1, new CodeInstruction[]
+            LocalBuilder handler = generator.DeclareLocal(typeof(PlayerHandler));
+            LocalBuilder curr = generator.DeclareLocal(typeof(CurrentlyUsedItem));
+
+            Label retLabel = generator.DefineLabel();
+
+            // add retLabel to return
+            newInstructions[newInstructions.Count - 1].WithLabels(retLabel);
+
+            // before ServerRemoveSelf, 2 instructions behind the return instruction
+            newInstructions.InsertRange(newInstructions.Count - 1 - 2, new CodeInstruction[]
             {
+                // if (!UsableItemsController.Handlers.TryGetValue(Owner, out PlayerHandler handler) return;
+                new(OpCodes.Ldsfld, Field(typeof(UsableItemsController), nameof(UsableItemsController.Handlers))),
+                new(OpCodes.Ldarg_0),
+                new(OpCodes.Callvirt, PropertyGetter(typeof(Consumable), nameof(Consumable.Owner))),
+                new(OpCodes.Ldloca_S, handler),
+                new(OpCodes.Callvirt, Method(typeof(Dictionary<ReferenceHub, PlayerHandler>), nameof(Dictionary<ReferenceHub, PlayerHandler>.TryGetValue))),
+                new(OpCodes.Brfalse_S, retLabel),
+
+                // CurrentlyUsedItem curr = handler.CurrentUsable;
+                new(OpCodes.Ldloc_S, handler),
+                new(OpCodes.Ldfld, Field(typeof(PlayerHandler), nameof(PlayerHandler.CurrentUsable))),
+                new(OpCodes.Stloc_S, curr),
+
+                // if (curr.ItemSerial == 0) return;
+                new(OpCodes.Ldloc_S, curr),
+                new(OpCodes.Ldfld, Field(typeof(CurrentlyUsedItem), nameof(CurrentlyUsedItem.ItemSerial))),
+                new(OpCodes.Brfalse_S, retLabel),
+
+                // this check is to not call the event if the trigger was from UsableItemsController (the standard trigger for this event), contact @Someone on discord for more details
+                // if (Time.timeSinceLevelLoad >= currentUsable.StartTime + (currentUsable.Item.UseTime / cons.ItemTypeId.GetSpeedMultiplier(hub))) return;
+                new(OpCodes.Call, PropertyGetter(typeof(Time), nameof(Time.timeSinceLevelLoad))),
+                new(OpCodes.Ldloc_S, curr),
+                new(OpCodes.Ldfld, Field(typeof(CurrentlyUsedItem), nameof(CurrentlyUsedItem.StartTime))),
+                new(OpCodes.Ldloc_S, curr),
+                new(OpCodes.Ldfld, Field(typeof(CurrentlyUsedItem), nameof(CurrentlyUsedItem.Item))),
+                new(OpCodes.Ldfld, Field(typeof(UsableItem), nameof(UsableItem.UseTime))),
+                new(OpCodes.Ldarg_0),
+                new(OpCodes.Ldfld, Field(typeof(Consumable), nameof(Consumable.ItemTypeId))),
+                new(OpCodes.Ldarg_0),
+                new(OpCodes.Callvirt, PropertyGetter(typeof(Consumable), nameof(Consumable.Owner))),
+                new(OpCodes.Call, Method(typeof(UsableItemModifierEffectExtensions), nameof(UsableItemModifierEffectExtensions.GetSpeedMultiplier))),
+                new(OpCodes.Div),
+                new(OpCodes.Add),
+                new(OpCodes.Bgt_Un_S, retLabel),
+
                 // this.Owner
                 new(OpCodes.Ldarg_0),
                 new(OpCodes.Callvirt, PropertyGetter(typeof(Consumable), nameof(Consumable.Owner))),


### PR DESCRIPTION
## Description
**Describe the changes** 
I feel kinda dumb for not checking but honestly this fix was really annoying to research. NW should really refactor their old code, they could probably get more functionality + features for modders if they did so.

**What is the current behavior?** (You can also link to an open issue here)
see title

**What is the new behavior?** (if this is a feature change)
its not called twice, nor should it be possible

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
I think I've handled every sane edge case but if there's any bug in my patch, players can be disconnected just for holstering a consumable so tread carefully when reviewing this.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
