### PR TITLE
feat: Append ModDescription not override it

### DIFF
--- a/EXILED/Exiled.Loader/Loader.cs
+++ b/EXILED/Exiled.Loader/Loader.cs
@@ -511,7 +511,7 @@ namespace Exiled.Loader
 
             EnablePlugins();
 
-            BuildInfoCommand.ModDescription = string.Join(
+            BuildInfoCommand.ModDescription += string.Join(
                 "\n",
                 AppDomain.CurrentDomain.GetAssemblies()
                     .Where(a => a.FullName.StartsWith("Exiled.", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Description
**Describe the changes** 
Changed the `=` to `+=` to append into ModDescription not override it.

**What is the current behavior?** (You can also link to an open issue here)
Overriding any description that set before exiled.

**What is the new behavior?** (if this is a feature change)
Append after any change made to ModDescription before exiled run.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
