### PR TITLE
feat: add generic singleton Instance pattern for CustomItem and CustomRole

### DIFF
--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem{T}.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem{T}.cs
@@ -1,0 +1,181 @@
+// -----------------------------------------------------------------------
+// <copyright file="CustomItem{T}.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+#pragma warning disable SA1402 // File may only contain a single type
+namespace Exiled.CustomItems.API.Features
+{
+    using YamlDotNet.Serialization;
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomItem"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomItem"/> type.</typeparam>
+    public abstract class CustomItem<T> : CustomItem
+        where T : CustomItem<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomItem"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomWeapon"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomWeapon"/> type.</typeparam>
+    public abstract class CustomWeapon<T> : CustomWeapon
+        where T : CustomWeapon<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomWeapon"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomKeycard"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomKeycard"/> type.</typeparam>
+    public abstract class CustomKeycard<T> : CustomKeycard
+        where T : CustomKeycard<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomKeycard"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomGrenade"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomGrenade"/> type.</typeparam>
+    public abstract class CustomGrenade<T> : CustomGrenade
+        where T : CustomGrenade<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomGrenade"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomArmor"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomArmor"/> type.</typeparam>
+    public abstract class CustomArmor<T> : CustomArmor
+        where T : CustomArmor<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomArmor"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomGoggles"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomGoggles"/> type.</typeparam>
+    public abstract class CustomGoggles<T> : CustomGoggles
+
+        where T : CustomGoggles<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomGoggles"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+}
+#pragma warning restore SA1402 // File may only contain a single type

--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem{T}.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem{T}.cs
@@ -154,7 +154,6 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomGoggles"/> type.</typeparam>
     public abstract class CustomGoggles<T> : CustomGoggles
-
         where T : CustomGoggles<T>
     {
         /// <summary>

--- a/EXILED/Exiled.CustomItems/API/Features/CustomItem{T}.cs
+++ b/EXILED/Exiled.CustomItems/API/Features/CustomItem{T}.cs
@@ -14,7 +14,7 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomItem"/> type.</typeparam>
     public abstract class CustomItem<T> : CustomItem
-        where T : CustomItem<T>
+        where T : CustomItem<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomItem"/>.
@@ -42,7 +42,7 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomWeapon"/> type.</typeparam>
     public abstract class CustomWeapon<T> : CustomWeapon
-        where T : CustomWeapon<T>
+        where T : CustomWeapon<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomWeapon"/>.
@@ -70,7 +70,7 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomKeycard"/> type.</typeparam>
     public abstract class CustomKeycard<T> : CustomKeycard
-        where T : CustomKeycard<T>
+        where T : CustomKeycard<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomKeycard"/>.
@@ -98,7 +98,7 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomGrenade"/> type.</typeparam>
     public abstract class CustomGrenade<T> : CustomGrenade
-        where T : CustomGrenade<T>
+        where T : CustomGrenade<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomGrenade"/>.
@@ -126,7 +126,7 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomArmor"/> type.</typeparam>
     public abstract class CustomArmor<T> : CustomArmor
-        where T : CustomArmor<T>
+        where T : CustomArmor<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomArmor"/>.
@@ -154,7 +154,7 @@ namespace Exiled.CustomItems.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomGoggles"/> type.</typeparam>
     public abstract class CustomGoggles<T> : CustomGoggles
-        where T : CustomGoggles<T>
+        where T : CustomGoggles<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomGoggles"/>.

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole{T}.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole{T}.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="CustomRole{T}.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.CustomRoles.API.Features
+{
+    using YamlDotNet.Serialization;
+
+    /// <summary>
+    /// A generic base class for <see cref="CustomRole"/> that provides a typed singleton <see cref="Instance"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="CustomRole"/> type.</typeparam>
+    public abstract class CustomRole<T> : CustomRole
+        where T : CustomRole<T>
+    {
+        /// <summary>
+        /// Gets the singleton instance of this <see cref="CustomRole"/>.
+        /// </summary>
+        [YamlIgnore]
+        public static T? Instance { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Init()
+        {
+            base.Init();
+            Instance = this as T;
+        }
+
+        /// <inheritdoc/>
+        public override void Destroy()
+        {
+            Instance = null;
+            base.Destroy();
+        }
+    }
+}

--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole{T}.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole{T}.cs
@@ -14,7 +14,7 @@ namespace Exiled.CustomRoles.API.Features
     /// </summary>
     /// <typeparam name="T">The concrete <see cref="CustomRole"/> type.</typeparam>
     public abstract class CustomRole<T> : CustomRole
-        where T : CustomRole<T>
+        where T : CustomRole<T>, new()
     {
         /// <summary>
         /// Gets the singleton instance of this <see cref="CustomRole"/>.


### PR DESCRIPTION
## Description
**Describe the changes** 
Adds CustomItem<T>, CustomRole<T> and typed wrappers for all subclasses (CustomWeapon<T>, CustomKeycard<T>, CustomArmor<T>, CustomGrenade<T>, CustomGoggles<T>). Instead of fetching instances via Get(id) or Get(name) which are fragile since ids and names can change at any time with configs, other plugins can now reference a custom item or role directly via example MyCustomGoggles.Instance or MyCustomRole.Instance, getting full strongly typed access to all properties and methods without any casting. This makes cross plugin integrations simpler, less error prone, and more accessible to developers who aren't deeply familiar with the codebase.

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
Example usage 
<img width="354" height="46" alt="image" src="https://github.com/user-attachments/assets/58a3904c-8d6c-4b89-9d1a-986767b259b8" />

on another  plugin via referance or another class

<img width="501" height="54" alt="image" src="https://github.com/user-attachments/assets/78372b2b-7b38-4d34-9ea1-252a20c0efcd" />


<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
