### PR TITLE
fix: wave method naming and add force pause support

### DIFF
--- a/EXILED/Exiled.API/Features/Respawn.cs
+++ b/EXILED/Exiled.API/Features/Respawn.cs
@@ -393,7 +393,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="spawnableFaction">The faction associated with the respawn wave.</param>
         /// <param name="isForcePause">True to pause the wave timer, false to resume it.</param>
-        public static void PauseWave(SpawnableFaction spawnableFaction, bool isForcePause = true)
+        public static void ForcePauseWave(SpawnableFaction spawnableFaction, bool isForcePause = true)
         {
             if (TryGetWaveBase(spawnableFaction, out SpawnableWaveBase spawnableWaveBase))
             {
@@ -413,7 +413,7 @@ namespace Exiled.API.Features
         /// <remarks>
         /// Unlike ClearWaves, this does not remove waves from the system, it only controls their timer state.
         /// </remarks>
-        public static void PauseWaves(bool isForcePause = true)
+        public static void ForcePauseWaves(bool isForcePause = true)
         {
             foreach (SpawnableWaveBase wave in WaveManager.Waves)
             {
@@ -431,19 +431,20 @@ namespace Exiled.API.Features
         /// <param name="spawnableFactions">
         /// A list of <see cref="SpawnableFaction"/> instances representing the waves to pause.
         /// </param>
-        public static void PauseWaves(List<SpawnableFaction> spawnableFactions)
+        public static void ForcePauseWaves(List<SpawnableFaction> spawnableFactions)
         {
             foreach (SpawnableFaction spawnableFaction in spawnableFactions)
             {
-                PauseWave(spawnableFaction);
+                ForcePauseWave(spawnableFaction);
             }
         }
 
         /// <summary>
-        /// Removes a respawn wave from the active wave list and adds it to the paused wave list.
+        /// Pauses a specific respawn wave by removing it from the active wave list and adding it to the paused wave list.
         /// </summary>
-        /// <param name="spawnableFaction">The faction whose respawn wave will be cleared from active waves.</param>
-        public static void ClearWave(SpawnableFaction spawnableFaction)
+        /// <param name="spawnableFaction">The <see cref="SpawnableFaction"/> representing the wave to pause.</param>
+        [Obsolete("Use ForcePauseWave instead. PauseWave breaks wave systems after game update.")]
+        public static void PauseWave(SpawnableFaction spawnableFaction)
         {
             if (TryGetWaveBase(spawnableFaction, out SpawnableWaveBase spawnableWaveBase))
             {
@@ -460,13 +461,11 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Clears all active respawn waves from <see cref="WaveManager.Waves"/>.
-        /// and stores them in <see cref="PausedWaves"/> for later restoration.
+        /// Pauses respawn waves by removing them from <see cref="WaveManager.Waves">WaveManager.Waves</see> and storing them in <see cref="PausedWaves"/>.
         /// </summary>
-        /// <remarks>
-        /// This completely removes waves from the active wave list.
-        /// </remarks>
-        public static void ClearWaves()
+        /// <!--Beryl said this should work fine but it requires testing-->
+        [Obsolete("Use ForcePauseWaves instead. PauseWaves breaks wave systems after game update.")]
+        public static void PauseWaves()
         {
             PausedWaves.Clear();
             PausedWaves.AddRange(WaveManager.Waves);
@@ -480,7 +479,8 @@ namespace Exiled.API.Features
         /// <param name="spawnableFactions">
         /// A list of <see cref="SpawnableFaction"/> instances representing the waves to pause.
         /// </param>
-        public static void ClearWaves(List<SpawnableFaction> spawnableFactions)
+        [Obsolete("Use ForcePauseWaves instead. PauseWaves breaks wave systems after game update.")]
+        public static void PauseWaves(List<SpawnableFaction> spawnableFactions)
         {
             foreach (SpawnableFaction spawnableFaction in spawnableFactions)
             {

--- a/EXILED/Exiled.API/Features/Respawn.cs
+++ b/EXILED/Exiled.API/Features/Respawn.cs
@@ -431,7 +431,7 @@ namespace Exiled.API.Features
         /// <remarks>
         /// Unlike ClearWaves, this does not remove waves from the system, it only controls their timer state.
         /// </remarks>
-        public static void ForcePauseWaves(bool isForcePause = true)
+        public static void PauseWaves(bool isForcePause = true)
         {
             foreach (SpawnableWaveBase wave in WaveManager.Waves)
             {

--- a/EXILED/Exiled.API/Features/Respawn.cs
+++ b/EXILED/Exiled.API/Features/Respawn.cs
@@ -409,7 +409,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Clears all active respawn waves from <see cref="WaveManager.Waves"/> 
+        /// Clears all active respawn waves from <see cref="WaveManager.Waves"/>.
         /// and stores them in <see cref="PausedWaves"/> for later restoration.
         /// </summary>
         /// <remarks>

--- a/EXILED/Exiled.API/Features/Respawn.cs
+++ b/EXILED/Exiled.API/Features/Respawn.cs
@@ -389,37 +389,19 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Pauses a specific respawn wave by removing it from the active wave list and adding it to the paused wave list.
+        /// Forcefully pauses or resumes the timer of a time-based respawn wave for the specified faction.
         /// </summary>
-        /// <param name="spawnableFaction">The <see cref="SpawnableFaction"/> representing the wave to pause.</param>
-        public static void PauseWave(SpawnableFaction spawnableFaction)
+        /// <param name="spawnableFaction">The faction associated with the respawn wave.</param>
+        /// <param name="isForcePause">True to pause the wave timer, false to resume it.</param>
+        public static void PauseWave(SpawnableFaction spawnableFaction, bool isForcePause = true)
         {
             if (TryGetWaveBase(spawnableFaction, out SpawnableWaveBase spawnableWaveBase))
             {
-                if (!PausedWaves.Contains(spawnableWaveBase))
+                if (spawnableWaveBase is TimeBasedWave timeBasedWave)
                 {
-                    PausedWaves.Add(spawnableWaveBase);
-                }
-
-                if (WaveManager.Waves.Contains(spawnableWaveBase))
-                {
-                    WaveManager.Waves.Remove(spawnableWaveBase);
+                    timeBasedWave.Timer.IsForcefullyPaused = isForcePause;
                 }
             }
-        }
-
-        /// <summary>
-        /// Clears all active respawn waves from <see cref="WaveManager.Waves"/>.
-        /// and stores them in <see cref="PausedWaves"/> for later restoration.
-        /// </summary>
-        /// <remarks>
-        /// This completely removes waves from the active wave list.
-        /// </remarks>
-        public static void ClaerWaves()
-        {
-            PausedWaves.Clear();
-            PausedWaves.AddRange(WaveManager.Waves);
-            WaveManager.Waves.Clear();
         }
 
         /// <summary>
@@ -450,6 +432,55 @@ namespace Exiled.API.Features
         /// A list of <see cref="SpawnableFaction"/> instances representing the waves to pause.
         /// </param>
         public static void PauseWaves(List<SpawnableFaction> spawnableFactions)
+        {
+            foreach (SpawnableFaction spawnableFaction in spawnableFactions)
+            {
+                PauseWave(spawnableFaction);
+            }
+        }
+
+        /// <summary>
+        /// Removes a respawn wave from the active wave list and adds it to the paused wave list.
+        /// </summary>
+        /// <param name="spawnableFaction">The faction whose respawn wave will be cleared from active waves.</param>
+        public static void ClearWave(SpawnableFaction spawnableFaction)
+        {
+            if (TryGetWaveBase(spawnableFaction, out SpawnableWaveBase spawnableWaveBase))
+            {
+                if (!PausedWaves.Contains(spawnableWaveBase))
+                {
+                    PausedWaves.Add(spawnableWaveBase);
+                }
+
+                if (WaveManager.Waves.Contains(spawnableWaveBase))
+                {
+                    WaveManager.Waves.Remove(spawnableWaveBase);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all active respawn waves from <see cref="WaveManager.Waves"/>.
+        /// and stores them in <see cref="PausedWaves"/> for later restoration.
+        /// </summary>
+        /// <remarks>
+        /// This completely removes waves from the active wave list.
+        /// </remarks>
+        public static void ClearWaves()
+        {
+            PausedWaves.Clear();
+            PausedWaves.AddRange(WaveManager.Waves);
+            WaveManager.Waves.Clear();
+        }
+
+        /// <summary>
+        /// Pauses the specified list of respawn waves by iterating through each wave
+        /// and pausing it using the <see cref="PauseWave(SpawnableFaction)"/> method.
+        /// </summary>
+        /// <param name="spawnableFactions">
+        /// A list of <see cref="SpawnableFaction"/> instances representing the waves to pause.
+        /// </param>
+        public static void ClearWaves(List<SpawnableFaction> spawnableFactions)
         {
             foreach (SpawnableFaction spawnableFaction in spawnableFactions)
             {

--- a/EXILED/Exiled.API/Features/Respawn.cs
+++ b/EXILED/Exiled.API/Features/Respawn.cs
@@ -423,18 +423,21 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Temporarily pauses all time-based respawn waves by forcefully stopping their timers.
+        /// Forcefully pauses or resumes all time-based respawn waves by controlling their timers.
         /// </summary>
+        /// <param name="isForcePause">
+        /// If true, all time-based waves will be paused. If false, their timers will resume.
+        /// </param>
         /// <remarks>
-        /// Unlike ClearWaves, this does not remove waves, it only stops their progression.
+        /// Unlike ClearWaves, this does not remove waves from the system, it only controls their timer state.
         /// </remarks>
-        public static void PauseWaves()
+        public static void ForcePauseWaves(bool isForcePause = true)
         {
             foreach (SpawnableWaveBase wave in WaveManager.Waves)
             {
                 if (wave is TimeBasedWave timeBasedWave)
                 {
-                    timeBasedWave.Timer.IsForcefullyPaused = true;
+                    timeBasedWave.Timer.IsForcefullyPaused = isForcePause;
                 }
             }
         }

--- a/EXILED/Exiled.API/Features/Respawn.cs
+++ b/EXILED/Exiled.API/Features/Respawn.cs
@@ -409,14 +409,34 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Pauses respawn waves by removing them from <see cref="WaveManager.Waves">WaveManager.Waves</see> and storing them in <see cref="PausedWaves"/>.
+        /// Clears all active respawn waves from <see cref="WaveManager.Waves"/> 
+        /// and stores them in <see cref="PausedWaves"/> for later restoration.
         /// </summary>
-        /// <!--Beryl said this should work fine but it requires testing-->
-        public static void PauseWaves()
+        /// <remarks>
+        /// This completely removes waves from the active wave list.
+        /// </remarks>
+        public static void ClaerWaves()
         {
             PausedWaves.Clear();
             PausedWaves.AddRange(WaveManager.Waves);
             WaveManager.Waves.Clear();
+        }
+
+        /// <summary>
+        /// Temporarily pauses all time-based respawn waves by forcefully stopping their timers.
+        /// </summary>
+        /// <remarks>
+        /// Unlike ClearWaves, this does not remove waves, it only stops their progression.
+        /// </remarks>
+        public static void PauseWaves()
+        {
+            foreach (SpawnableWaveBase wave in WaveManager.Waves)
+            {
+                if (wave is TimeBasedWave timeBasedWave)
+                {
+                    timeBasedWave.Timer.IsForcefullyPaused = true;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
**Describe the changes** 
Refactored wave management methods to better reflect their actual behavior and added proper pause control functionality:

- Renamed the old PauseWaves() method to ClearWaves() since it was clearing waves instead of pausing them.
- Implemented a new ForcePauseWaves(bool) method to properly pause and resume time-based waves.
- Fixed incorrect XML documentation to match the real behavior of these methods.

**What is the current behavior?** (You can also link to an open issue here)
- Previously PauseWaves() was incorrectly named and removed waves instead of pausing them. There was no proper way to pause wave timers without removing them from the system.

**What is the new behavior?** (if this is a feature change)
- ClearWaves() now correctly represents wave removal.
- New ForcePauseWaves(bool) allows force pausing and resuming wave timers.
- Documentation now correctly reflects method behavior.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- Possibly. If any plugins relied on the old PauseWaves() behavior they may need to update their code to use ClearWaves() instead.

**Other information**:
- Improves API clarity and provides better control over wave timing behavior.

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [X] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
