### PR TITLE
feat: Changes to ReadPickupInfoBefore to include more information when converting between Pickup and Item.

### DIFF
--- a/EXILED/Exiled.API/Features/Items/Firearm.cs
+++ b/EXILED/Exiled.API/Features/Items/Firearm.cs
@@ -814,6 +814,11 @@ namespace Exiled.API.Features.Items
             {
                 PrimaryMagazine.MaxAmmo = firearmPickup.MaxAmmo;
                 AmmoDrain = firearmPickup.AmmoDrain;
+
+                Damage = firearmPickup.Damage;
+                Inaccuracy = firearmPickup.Inaccuracy;
+                Penetration = firearmPickup.Penetration;
+                DamageFalloffDistance = firearmPickup.DamageFalloffDistance;
             }
         }
     }

--- a/EXILED/Exiled.API/Features/Items/Firearm.cs
+++ b/EXILED/Exiled.API/Features/Items/Firearm.cs
@@ -814,7 +814,6 @@ namespace Exiled.API.Features.Items
             {
                 PrimaryMagazine.MaxAmmo = firearmPickup.MaxAmmo;
                 AmmoDrain = firearmPickup.AmmoDrain;
-
                 Damage = firearmPickup.Damage;
                 Inaccuracy = firearmPickup.Inaccuracy;
                 Penetration = firearmPickup.Penetration;

--- a/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
+++ b/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
@@ -128,6 +128,26 @@ namespace Exiled.API.Features.Pickups
         /// <returns>A string containing FirearmPickup related data.</returns>
         public override string ToString() => $"{Type} ({Serial}) [{Weight}] *{Scale}*";
 
+        /// <summary>
+        /// Gets or sets the damage for this <see cref="FirearmPickup"/>.
+        /// </summary>
+        public float Damage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the inaccuracy for this <see cref="FirearmPickup"/>.
+        /// </summary>
+        public float Inaccuracy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the penetration for this <see cref="FirearmPickup"/>.
+        /// </summary>
+        public float Penetration { get; set; }
+
+        /// <summary>
+        /// Gets or sets how much fast the value drop over the distance.
+        /// </summary>
+        public float DamageFalloffDistance { get; set; }
+
         /// <inheritdoc/>
         internal override void ReadItemInfo(Items.Item item)
         {
@@ -135,6 +155,11 @@ namespace Exiled.API.Features.Pickups
             {
                 MaxAmmo = firearm.PrimaryMagazine.ConstantMaxAmmo;
                 AmmoDrain = firearm.AmmoDrain;
+
+                Damage = firearm.Damage;
+                Inaccuracy = firearm.Inaccuracy;
+                Penetration = firearm.Penetration;
+                DamageFalloffDistance = firearm.DamageFalloffDistance;
             }
 
             base.ReadItemInfo(item);

--- a/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
+++ b/EXILED/Exiled.API/Features/Pickups/FirearmPickup.cs
@@ -118,17 +118,6 @@ namespace Exiled.API.Features.Pickups
         }
 
         /// <summary>
-        /// Initializes the item as if it was spawned naturally by map generation.
-        /// </summary>
-        public void Distribute() => Base.OnDistributed();
-
-        /// <summary>
-        /// Returns the FirearmPickup in a human-readable format.
-        /// </summary>
-        /// <returns>A string containing FirearmPickup related data.</returns>
-        public override string ToString() => $"{Type} ({Serial}) [{Weight}] *{Scale}*";
-
-        /// <summary>
         /// Gets or sets the damage for this <see cref="FirearmPickup"/>.
         /// </summary>
         public float Damage { get; set; }
@@ -148,6 +137,17 @@ namespace Exiled.API.Features.Pickups
         /// </summary>
         public float DamageFalloffDistance { get; set; }
 
+        /// <summary>
+        /// Initializes the item as if it was spawned naturally by map generation.
+        /// </summary>
+        public void Distribute() => Base.OnDistributed();
+
+        /// <summary>
+        /// Returns the FirearmPickup in a human-readable format.
+        /// </summary>
+        /// <returns>A string containing FirearmPickup related data.</returns>
+        public override string ToString() => $"{Type} ({Serial}) [{Weight}] *{Scale}*";
+
         /// <inheritdoc/>
         internal override void ReadItemInfo(Items.Item item)
         {
@@ -155,7 +155,6 @@ namespace Exiled.API.Features.Pickups
             {
                 MaxAmmo = firearm.PrimaryMagazine.ConstantMaxAmmo;
                 AmmoDrain = firearm.AmmoDrain;
-
                 Damage = firearm.Damage;
                 Inaccuracy = firearm.Inaccuracy;
                 Penetration = firearm.Penetration;


### PR DESCRIPTION
## Description
**Describe the changes** 
Includes properties from HitscanHitregModule to FirearmPickup, so they're not resetted everytime firearm is dropped.

**What is the current behavior?** (You can also link to an open issue here)
X

**What is the new behavior?** (if this is a feature change)
X

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Noupe.

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
