### PR TITLE
fix(README-FR): fix typos, grammar and translation errors

### DIFF
--- a/.github/documentation/localization/README-FR.md
+++ b/.github/documentation/localization/README-FR.md
@@ -30,7 +30,7 @@ Si vous choisissez d'utiliser l'installateur, il se chargera, s'il est exécuté
   - Placez-le dans le dossier de votre serveur (téléchargez le serveur dédié si vous ne l'avez pas encore fait)
   - Double-cliquez sur **`Exiled.Installer.exe`** ou **[téléchargez ce .bat](https://www.dropbox.com/scl/fi/7yh0r3q0vdn6ic4rhuu3l/install-prerelease.bat?rlkey=99fwjbwy1xg61qgtak0qzb9rd&st=8xs4xks8&dl=1)** et placez-le dans le dossier du serveur pour installer la dernière pré-version
   - Pour obtenir et installer des plugins, consultez la section [installation de plugin](#installation-de-plugin) ci-dessous.
-**Note:** Si vous installez EXILED sur un serveur distant, assurez-vous d'exécuter le .exe avec même utilisateur qui exécute vos serveurs SCP:SL (ou un utilisateur avec des privilèges d'administration)
+**Note:** Si vous installez EXILED sur un serveur distant, assurez-vous d'exécuter le .exe avec le même utilisateur qui exécute vos serveurs SCP:SL (ou un utilisateur avec des privilèges d'administration)
 
 ### Installation manuelle
   - Téléchargez **`Exiled.tar.gz` [ici](https://github.com/ExMod-Team/EXILED/releases)**
@@ -67,13 +67,13 @@ C'est tout, EXILED devrait maintenant être installé et actif la prochaine fois
   - Déplacez le dossier **`SCP Secret Laboratory`** vers **``~/.config``**. *Remarque : Ce dossier doit être placé dans ``~/.config``, et ***NON*** ``~/.config/SCP Secret Laboratory``* (SSH: **`mv SCP Secret Laboratory ~/.config/`**)
 
 ### Installation de plugins
-C'est tout, EXILED devrait maintenant être installé et actif la prochaine fois que vous démarrez votre serveur. Notez qu'EXILED par lui-même ne fera presque rien, alors assurez-vous d'obtenir des plugins depuis **[depuis notre serveur Discord](https://discord.gg/PyUkWTg)**
+C'est tout, EXILED devrait maintenant être installé et actif la prochaine fois que vous démarrez votre serveur. Notez qu'EXILED par lui-même ne fera presque rien, alors assurez-vous d'obtenir des plugins depuis **[notre serveur Discord](https://discord.gg/PyUkWTg)**
 - Pour installer un plugin, simplement :
   - Téléchargez un plugin depuis [*sa page de release*](https://i.imgur.com/u34wgPD.jpg) (**il DOIT s'agir d'un fichier `.dll`!**)
   - Déplacez-le vers: ``~/.config/EXILED/Plugins`` (si vous utilisez SSH en tant que root, alors recherchez le `.config` correct qui sera à l'intérieur de `/home/(SCP Server User)`)
 
 # Config
-EXILED quelques options de configuration.
+EXILED offre quelques options de configuration.
 Toutes sont générées automatiquement au démarrage du serveur et se trouvent dans le fichier  ``~/.config/EXILED/Configs/(ServerPortHere)-config.yml`` (``%AppData%\EXILED\Configs\(ServerPortHere)-config.yml`` sur Windows).
 
 Les configurations des plugins ***NE seront PAS*** dans le fichier ``config_gameplay.txt`` mentionné précédemment. Au lieu de cela, les configurations des plugins sont définies dans le fichier ``~/.config/EXILED/Configs/(ServerPortHere)-config.yml`` (``%AppData%\EXILED\(ServerPortHere)-config.yml`` sur Windows).
@@ -87,14 +87,14 @@ Pour des tutoriels plus complets et régulièrement mis à jour, consultez [le s
 
 Mais veuillez faire attention à suivre les règles suivantes lorsque vous publiez vos plugins :
 
-- Votre plugin doit contenir une classe appartenant à ``Exiled.API.Features.Plugin<>``, sinon EXILED ne chargera pas votre plugin lorsque le serveur démarrera.
+- Votre plugin doit contenir une classe héritant de ``Exiled.API.Features.Plugin<>``, sinon EXILED ne chargera pas votre plugin lorsque le serveur démarrera.
 - Lorsqu'un plugin est chargé, le code de la classe mentionnée précédemment dans ``OnEnabled()`` est immédiatement exécuté et n'attend pas que les autres plugins soient chargés. Il n'attend pas non plus que le démarrage du serveur soit terminé. ***Il n'attend rien du tout.*** Lors de la mise en place de votre méthode ``OnEnabled()``, assurez-vous de ne pas accéder à des choses qui ne devraient pas être démarrées par le serveur à ce moment-là, comme par exemple ``ServerConsole.Port``, ou ``PlayerManager.localPlayer``.
 - Si vous avez besoin d'accéder à certaines choses avant que votre plugin ne soit chargé, il est recommandé d'attendre l'événement ``WaitingForPlayers`` pour cela. Sinon, encadrez votre code d'une boucle ``while(!x)`` qui vérifie si votre variable/objet qui a besoin de ne plus être ``NULL`` avant de continuer.
-- EXILED prend en charge le rechargement dynamique des assembly de plugins en cours d'exécution, ce qui signifie que si vous devez mettre à jour un plugin, cela peut être fait sans redémarrer le serveur. Cependant, si vous mettez à jour un plugin en cours d'exécution, le plugin doit être correctement configuré pour le prendre en charge, sinon vous rencontrerez des problèmes. Consultez la section [Mise à jour Dynamiques](#mise-a-jour-dynamiques) pour plus d'informations et de directives à suivre.
+- EXILED prend en charge le rechargement dynamique des assembly de plugins en cours d'exécution, ce qui signifie que si vous devez mettre à jour un plugin, cela peut être fait sans redémarrer le serveur. Cependant, si vous mettez à jour un plugin en cours d'exécution, le plugin doit être correctement configuré pour le prendre en charge, sinon vous rencontrerez des problèmes. Consultez la section [Mises à jour dynamiques](#mises-à-jour-dynamiques) pour plus d'informations et de directives à suivre.
 - Il n'y a ***AUCUN*** événement ``OnUpdate``, ``OnFixedUpdate`` ou ``OnLateUpdate`` dans EXILED. Si vous devez exécuter du code aussi souvent, vous pouvez utiliser des coroutines de MEC (ou More Effective Coroutines) qui attendent une frame, 0.01f, ou utiliser une couche de synchronisation comme ``Timing.FixedUpdate`` à la place.
  ### Les coroutines de MEC
-Si vous n'êtes pas familier avec MEC, voici une breve et simple explication pour vous aider à démarrer.
-Les coroutines MEC sont essentiellement des méthodes chronométrées qui prennent en charge des périodes d'attente avant de poursuivre l'exécution, sans interrompre/pausé le thread principal du jeu.
+Si vous n'êtes pas familier avec MEC, voici une brève et simple introduction pour vous aider à démarrer.
+Les coroutines MEC sont essentiellement des méthodes chronométrées qui prennent en charge des périodes d'attente avant de poursuivre l'exécution, sans interrompre ni mettre en pause le thread principal du jeu.
 Les coroutines MEC sont sûres à utiliser avec Unity, contrairement au threading traditionnel. ***NE TENTEZ PAS de créer de nouveaux threads pour interagir avec Unity, cela FERA planter le serveur.***
 
 Pour utiliser MEC, vous devrez référencer ``Assembly-CSharp-firstpass.dll`` depuis les fichiers du serveur et inclure ``using MEC;``.
@@ -111,9 +111,9 @@ public void SomeMethod()
 
 public IEnumerator<float> MyCoroutine()
 {
-    for (;;) //fonctione infinie
+    for (;;) //répète ce qui suit indéfiniment
     {
-        Log.Info("Hey Je suis une boucle infini!"); //appel à Log.Info pour écrire une ligne sur la console du serveur.
+        Log.Info("Hey, je suis une boucle infinie!"); //appel à Log.Info pour écrire une ligne sur la console du serveur.
         yield return Timing.WaitForSeconds(5f); //Dit à la coroutine d'attendre 5 secondes avant de continuer. Comme c'est à la fin de la boucle, cela empêche effectivement la boucle de se répéter pendant 5 secondes.
     }
 }
@@ -121,7 +121,7 @@ public IEnumerator<float> MyCoroutine()
 
 Il est ***fortement*** recommandé de faire quelques recherches sur Google ou de demander autour de vous sur Discord si vous n'êtes pas familier avec MEC et que vous souhaitez en apprendre d'avantage, obtenir des conseils ou de l'aide. Les questions, aussi 'bêtes' soient-elles, seront toujours répondues de manière aussi utile et claire que possible pour aider les développeurs de plugins à exceller. Un meilleur code profite à tout le monde.
 
-### Mise a jour Dynamiques
+### Mises à jour dynamiques
 EXILED en tant que framework prend en charge le rechargement dynamique des assembly de plugins sans nécessité de redémarrage du serveur.
 Par exemple, si vous démarrez le serveur avec juste ``Exiled.Events`` comme seul plugin, et que vous souhaitez en ajouter un nouveau, vous n'avez pas besoin de redémarrer le serveur pour accomplir cette tâche. Vous pouvez simplement utiliser la commande de la console à distance ou de la console du serveur ``reload plugins`` pour recharger tous les plugins EXILED, y compris les nouveaux qui n'ont pas été chargés auparavant.
 
@@ -137,7 +137,7 @@ Cela signifie également que vous pouvez *mettre à jour* les plugins sans avoir
  - Les plugins comportant des patches ``Harmony`` personnalisés doivent utiliser une sorte de variable changeante dans le nom de l'instance ``Harmony``, et doivent appeler ``UnPatchAll()`` sur leur instance Harmony lorsque le plugin est désactivé ou rechargé.
  - Toutes les coroutines démarrées par le plugin dans ``OnEnabled()`` doivent également être arrêtées lorsque le plugin est désactivé ou rechargé.
 
-Tout cela peut être réalisé dans les méthodes ``OnReloaded()`` ou ``OnDisabled()`` de la classe du plugin. Lorsque EXILED, recharge les plugins, il appelle ``OnDisabled()``, puis ``OnReloaded()``, puis il chargera les nouvelles assembly, et ensuite exécutera ``OnEnabled()``.
+Tout cela peut être réalisé dans les méthodes ``OnReloaded()`` ou ``OnDisabled()`` de la classe du plugin. Lorsque EXILED recharge les plugins, il appelle ``OnDisabled()``, puis ``OnReloaded()``, puis il chargera les nouvelles assembly, et ensuite exécutera ``OnEnabled()``.
 
 Notez qu'il s'agit de *nouvelles* assembly. Si vous remplacez une ``assembly`` par une autre portant le même nom, elle ne sera ***PAS*** mise à jour. Cela est dû au GAC (Global Assembly Cache) ; si vous tentez de "charger" une ``assembly`` qui est déjà en cache, elle utilisera toujours l'``assembly`` mise en cache.
 Pour cette raison, si votre plugin prend en charge les mises à jour dynamiques, vous devez construire chaque version avec un nom d'``assembly`` différent dans les options choisis (renommer le fichier ne fonctionnera pas). De plus, étant donné que l'ancienne ``assembly`` n'est pas "supprimé" lorsqu'elle n'est plus nécessaire, si vous ne vous désabonnez pas des événements, ne démontez pas votre instance ``Harmony``, n'arrêtez pas les coroutines, etc. Ce code continuera également à s'exécuter ainsi que celui de la nouvelle version.


### PR DESCRIPTION
## Description
**Describe the changes**
Fixed multiple typos, grammar mistakes and translation errors in the French README.

**What is the current behavior?**
The French README contained several errors: missing verb, duplicate word, missing articles, wrong translation of "inherits from", missing accents, grammatical errors and typos in code comments.

**What is the new behavior?**
N/A

**Does this PR introduce a breaking change?**
No.

**Other information**:
N/A

<br />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations

<br />

## Submission checklist
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
