### PR TITLE
fix: Fix SyncVarDirtyBits getter

### DIFF
--- a/EXILED/Exiled.API/Extensions/MirrorExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/MirrorExtensions.cs
@@ -25,6 +25,7 @@ namespace Exiled.API.Extensions
     using Exiled.API.Features.Pickups.Keycards;
     using Features;
     using Features.Pools;
+    using HarmonyLib;
     using InventorySystem;
     using InventorySystem.Items;
     using InventorySystem.Items.Autosync;
@@ -42,6 +43,7 @@ namespace Exiled.API.Extensions
     using PlayerRoles.Voice;
     using RelativePositioning;
     using Respawning;
+    using Unity.Collections.LowLevel.Unsafe;
     using UnityEngine;
     using Utils.Networking;
 
@@ -105,19 +107,38 @@ namespace Exiled.API.Extensions
                         if (setMethod is null)
                             continue;
 
-                        MethodBody methodBody = setMethod.GetMethodBody();
-
-                        if (methodBody is null)
-                            continue;
-
-                        byte[] bytecodes = methodBody.GetILAsByteArray();
+                        ulong bit = GetBit(setMethod);
 
                         if (!SyncVarDirtyBitsValue.ContainsKey($"{property.ReflectedType.Name}.{property.Name}"))
-                            SyncVarDirtyBitsValue.Add($"{property.ReflectedType.Name}.{property.Name}", bytecodes[bytecodes.LastIndexOf((byte)OpCodes.Ldc_I8.Value) + 1]);
+                            SyncVarDirtyBitsValue.Add($"{property.ReflectedType.Name}.{property.Name}", bit);
                     }
                 }
 
                 return ReadOnlySyncVarDirtyBitsValue;
+
+                ulong GetBit(MethodInfo setter)
+                {
+                    List<CodeInstruction> instructions = PatchProcessor.GetOriginalInstructions(setter);
+
+                    object operand = null;
+                    ulong bit;
+                    try
+                    {
+                        operand = instructions.Single(c => c.opcode == OpCodes.Ldc_I8).operand;
+                        long casted = (long)operand;
+
+                        // Standard casting doesn't work here because IL doesn't have a specific instruction for unsigned ulongs, it just loads it as a long and uses that.
+                        // Because of that, harmony here gives it back as a long, and standard casting would clamp the value if it was ever big enough, so we need an unsafe cast.
+                        bit = UnsafeUtility.As<long, ulong>(ref casted);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Error finding dirty bit in method {setter.ReflectedType.Name}.{setter.Name}! Found operand type: {operand?.GetType().Name ?? "Null"}. Exception: {ex}");
+                        return 0;
+                    }
+
+                    return bit;
+                }
             }
         }
 


### PR DESCRIPTION
## Description
**Describe the changes** 
Made the getter for SyncVarDirtyBits more robust by using harmony to get CodeInstructions to find the constant ulong inside the sync var setter methods, instead of checking the raw IL bytes for the Ldc_I8 opcode (which can cause issues because some constant values can be equivalent to the Ldc_I8 instruction by accident)

**What is the current behavior?** (You can also link to an open issue here)
Certain syncvars cant be faked using `SendFakeSyncVar` (WaypointToy.Priority, 3 ones in speaker, it's random tbh)

**What is the new behavior?** (if this is a feature change)
More `SendFakeSyncVar` stuff works

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
