### PR TITLE
docs: fix typos in XML documentation comments

### DIFF
--- a/EXILED/Exiled.API/Enums/EffectType.cs
+++ b/EXILED/Exiled.API/Enums/EffectType.cs
@@ -164,12 +164,12 @@ namespace Exiled.API.Enums
         Hypothermia,
 
         /// <summary>
-        /// Increases the affected player's motor function, causing the affected player to reduce the weapon draw time, reload spead, item pickup speed, and medical item usage.
+        /// Increases the affected player's motor function, causing the affected player to reduce the weapon draw time, reload speed, item pickup speed, and medical item usage.
         /// </summary>
         Scp1853,
 
         /// <summary>
-        /// Effect given to a player after being hurt by SCP-049. Deals 8 damage per second, after an inital 16 damage for the first second.
+        /// Effect given to a player after being hurt by SCP-049. Deals 8 damage per second, after an initial 16 damage for the first second.
         /// </summary>
         CardiacArrest,
 
@@ -204,7 +204,7 @@ namespace Exiled.API.Enums
         Scanned,
 
         /// <summary>
-        /// Teleports the affected player to the pocket dimension and drains their health until the affected player escapes the pocket dimension or is killed. The amount of damage recieved increases the longer the effect is applied.
+        /// Teleports the affected player to the pocket dimension and drains their health until the affected player escapes the pocket dimension or is killed. The amount of damage received increases the longer the effect is applied.
         /// </summary>
         PocketCorroding,
 

--- a/EXILED/Exiled.API/Enums/FacilityLayouts/EzFacilityLayout.cs
+++ b/EXILED/Exiled.API/Enums/FacilityLayouts/EzFacilityLayout.cs
@@ -18,7 +18,7 @@ namespace Exiled.API.Enums
     public enum EzFacilityLayout
     {
         /// <summary>
-        /// Represents an unknown layout. This value is only used if you try to access <see cref="Map.EzLayout"/> prematurely or if an error occured.
+        /// Represents an unknown layout. This value is only used if you try to access <see cref="Map.EzLayout"/> prematurely or if an error occurred.
         /// </summary>
         Unknown,
 

--- a/EXILED/Exiled.API/Enums/FacilityLayouts/HczFacilityLayout.cs
+++ b/EXILED/Exiled.API/Enums/FacilityLayouts/HczFacilityLayout.cs
@@ -18,7 +18,7 @@ namespace Exiled.API.Enums
     public enum HczFacilityLayout
     {
         /// <summary>
-        /// Represents an unknown layout. This value is only used if you try to access <see cref="Map.HczLayout"/> prematurely or if an error occured.
+        /// Represents an unknown layout. This value is only used if you try to access <see cref="Map.HczLayout"/> prematurely or if an error occurred.
         /// </summary>
         Unknown,
 

--- a/EXILED/Exiled.API/Enums/FacilityLayouts/LczFacilityLayout.cs
+++ b/EXILED/Exiled.API/Enums/FacilityLayouts/LczFacilityLayout.cs
@@ -18,7 +18,7 @@ namespace Exiled.API.Enums
     public enum LczFacilityLayout
     {
         /// <summary>
-        /// Represents an unknown layout. This value is only used if you try to access <see cref="Map.LczLayout"/> prematurely or if an error occured.
+        /// Represents an unknown layout. This value is only used if you try to access <see cref="Map.LczLayout"/> prematurely or if an error occurred.
         /// </summary>
         Unknown,
 

--- a/EXILED/Exiled.API/Enums/Scp939VisibilityStates.cs
+++ b/EXILED/Exiled.API/Enums/Scp939VisibilityStates.cs
@@ -15,12 +15,12 @@ namespace Exiled.API.Enums
     public enum Scp939VisibilityState
     {
         /// <summary>
-        /// SCP-939 doesnt see an other player, by default FPC role logic.
+        /// SCP-939 doesn't see an other player, by default FPC role logic.
         /// </summary>
         None,
 
         /// <summary>
-        /// SCP-939 doesnt see an player, by basic SCP-939 logic.
+        /// SCP-939 doesn't see an player, by basic SCP-939 logic.
         /// </summary>
         NotSeen,
 

--- a/EXILED/Exiled.API/Enums/Scp939VisibilityStates.cs
+++ b/EXILED/Exiled.API/Enums/Scp939VisibilityStates.cs
@@ -15,32 +15,32 @@ namespace Exiled.API.Enums
     public enum Scp939VisibilityState
     {
         /// <summary>
-        /// SCP-939 doesn't see an other player, by default FPC role logic.
+        /// SCP-939 doesn't see another player, by default FPC role logic.
         /// </summary>
         None,
 
         /// <summary>
-        /// SCP-939 doesn't see an player, by basic SCP-939 logic.
+        /// SCP-939 doesn't see a player, by basic SCP-939 logic.
         /// </summary>
         NotSeen,
 
         /// <summary>
-        /// SCP-939 sees an other player, who is teammate SCP.
+        /// SCP-939 sees another player, who is teammate SCP.
         /// </summary>
         SeenAsScp,
 
         /// <summary>
-        /// SCP-939 sees an other player due the Alpha Warhead detonation.
+        /// SCP-939 sees another player due the Alpha Warhead detonation.
         /// </summary>
         SeenByDetonation,
 
         /// <summary>
-        /// SCP-939 sees an other player, due the base-game vision range logic.
+        /// SCP-939 sees another player, due the base-game vision range logic.
         /// </summary>
         SeenByRange,
 
         /// <summary>
-        /// SCP-939 sees an other player for a while, after it's out of range.
+        /// SCP-939 sees another player for a while, after it's out of range.
         /// </summary>
         SeenByLastTime,
     }

--- a/EXILED/Exiled.API/Features/Core/StaticActor.cs
+++ b/EXILED/Exiled.API/Features/Core/StaticActor.cs
@@ -76,7 +76,7 @@ namespace Exiled.API.Features.Core
         /// <summary>
         /// Gets a <see cref="StaticActor"/> given the specified type.
         /// </summary>
-        /// <param name="type">The the type of the <see cref="StaticActor"/> to look for.</param>
+        /// <param name="type">The type of the <see cref="StaticActor"/> to look for.</param>
         /// <typeparam name="T">The type to cast the <see cref="StaticActor"/> to.</typeparam>
         /// <returns>The corresponding <see cref="StaticActor"/> of type <typeparamref name="T"/>, or <see langword="null"/> if not found.</returns>
         public static T Get<T>(Type type)
@@ -96,7 +96,7 @@ namespace Exiled.API.Features.Core
         /// <summary>
         /// Gets a <see cref="StaticActor"/> given the specified type.
         /// </summary>
-        /// <param name="type">The the type of the <see cref="StaticActor"/> to look for.</param>
+        /// <param name="type">The type of the <see cref="StaticActor"/> to look for.</param>
         /// <returns>The corresponding <see cref="StaticActor"/>.</returns>
         public static StaticActor Get(Type type)
         {

--- a/EXILED/Exiled.API/Features/Items/Throwable.cs
+++ b/EXILED/Exiled.API/Features/Items/Throwable.cs
@@ -93,7 +93,7 @@ namespace Exiled.API.Features.Items
         }
 
         /// <summary>
-        /// Cancel the throws of the item.
+        /// Cancels the throw of the item.
         /// </summary>
         public void CancelThrow() => Base.ServerProcessCancellation();
 

--- a/EXILED/Exiled.API/Features/Items/Throwable.cs
+++ b/EXILED/Exiled.API/Features/Items/Throwable.cs
@@ -93,7 +93,7 @@ namespace Exiled.API.Features.Items
         }
 
         /// <summary>
-        /// Cancel the the throws of the item.
+        /// Cancel the throws of the item.
         /// </summary>
         public void CancelThrow() => Base.ServerProcessCancellation();
 

--- a/EXILED/Exiled.API/Features/Pickups/Scp244Pickup.cs
+++ b/EXILED/Exiled.API/Features/Pickups/Scp244Pickup.cs
@@ -127,7 +127,7 @@ namespace Exiled.API.Features.Pickups
         /// Damages the Scp244Pickup.
         /// </summary>
         /// <param name="handler">The <see cref="DamageHandler"/> used to deal damage.</param>
-        /// <returns><see langword="true"/> if the the damage has been deal; otherwise, <see langword="false"/>.</returns>
+        /// <returns><see langword="true"/> if the damage has been dealt; otherwise, <see langword="false"/>.</returns>
         public bool Damage(DamageHandler handler) => Base.Damage(handler.Damage, handler, Vector3.zero);
 
         /// <summary>


### PR DESCRIPTION
## Description
**Describe the changes**

Corrects 12 spelling mistakes and doubled-word typos in `///` XML documentation comments across `Exiled.API`. These comments are surfaced in IntelliSense and on the docs site, so the fixes improve developer-facing copy. No code paths or signatures are touched.

**What is the current behavior?**

The XML documentation contains the typos listed above.

**What is the new behavior?** (if this is a feature change)

N/A.

**Does this PR introduce a breaking change?**

No. Comments only; no API or runtime behavior changes.

**Other information**:

N/A.

<br />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentations

<br />

## Submission checklist
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing