### PR TITLE
refactor: use nameof() in ArgumentNullException throws

### DIFF
--- a/EXILED/Exiled.API/Features/GlobalPatchProcessor.cs
+++ b/EXILED/Exiled.API/Features/GlobalPatchProcessor.cs
@@ -86,7 +86,7 @@ namespace Exiled.API.Features
                     }
 
                     if (string.IsNullOrEmpty(patchGroup.GroupId))
-                        throw new ArgumentNullException("GroupId");
+                        throw new ArgumentNullException(nameof(patchGroup.GroupId));
 
                     if (string.IsNullOrEmpty(groupId) || patchGroup.GroupId != groupId)
                         continue;
@@ -147,7 +147,7 @@ namespace Exiled.API.Features
                     goto Unpatch;
 
                 if (string.IsNullOrEmpty(patchGroup.GroupId))
-                    throw new ArgumentNullException("GroupId");
+                    throw new ArgumentNullException(nameof(patchGroup.GroupId));
 
                 if (string.IsNullOrEmpty(groupId) || patchGroup.GroupId != groupId)
                     continue;

--- a/EXILED/Exiled.CustomItems/API/Extensions.cs
+++ b/EXILED/Exiled.CustomItems/API/Extensions.cs
@@ -55,7 +55,7 @@ namespace Exiled.CustomItems.API
         public static void Register(this IEnumerable<CustomItem> customItems)
         {
             if (customItems is null)
-                throw new ArgumentNullException("customItems");
+                throw new ArgumentNullException(nameof(customItems));
 
             foreach (CustomItem customItem in customItems)
                 customItem.TryRegister();
@@ -74,7 +74,7 @@ namespace Exiled.CustomItems.API
         public static void Unregister(this IEnumerable<CustomItem> customItems)
         {
             if (customItems is null)
-                throw new ArgumentNullException("customItems");
+                throw new ArgumentNullException(nameof(customItems));
 
             foreach (CustomItem customItem in customItems)
                 customItem.TryUnregister();

--- a/EXILED/Exiled.Loader/Features/Configs/CommentGatheringTypeInspector.cs
+++ b/EXILED/Exiled.Loader/Features/Configs/CommentGatheringTypeInspector.cs
@@ -27,7 +27,7 @@ namespace Exiled.Loader.Features.Configs
         /// <param name="innerTypeDescriptor">The inner type description instance.</param>
         public CommentGatheringTypeInspector(ITypeInspector innerTypeDescriptor)
         {
-            this.innerTypeDescriptor = innerTypeDescriptor ?? throw new ArgumentNullException("innerTypeDescriptor");
+            this.innerTypeDescriptor = innerTypeDescriptor ?? throw new ArgumentNullException(nameof(innerTypeDescriptor));
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Description
**Describe the changes**

Replaces hardcoded string literals with `nameof()` expressions in `ArgumentNullException` throws so the parameter names stay in sync if the underlying parameter or property is ever renamed.

Files touched:
- `Exiled.CustomItems/API/Extensions.cs` - `Register` and `Unregister` (x2)
- `Exiled.Loader/Features/Configs/CommentGatheringTypeInspector.cs` - constructor (x1)
- `Exiled.API/Features/GlobalPatchProcessor.cs` - `PatchAll` and `UnpatchAll` (x2)

For `GlobalPatchProcessor`, the literal `"GroupId"` referenced the property `PatchGroupAttribute.GroupId` (the value being checked is `patchGroup.GroupId`); switched to `nameof(patchGroup.GroupId)` to preserve the same string while making it refactor-safe.

**What is the current behavior?**

Throws `ArgumentNullException` with hardcoded string literals as parameter names.

**What is the new behavior?** (if this is a feature change)

Same exception, same parameter name string, just sourced via `nameof()`.

**Does this PR introduce a breaking change?**

No.

**Other information**:

N/A.

<br />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations

<br />

## Submission checklist
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing