### PR TITLE
fix: Installer always returns exit code 0 even on failure

### DIFF
--- a/EXILED/Exiled.Installer/Program.cs
+++ b/EXILED/Exiled.Installer/Program.cs
@@ -155,6 +155,7 @@ namespace Exiled.Installer
             }
             catch (Exception ex)
             {
+                error = true;
                 Console.WriteLine(ex);
                 Console.WriteLine(Resources.Program_MainSafe_Read_the_exception_message__read_the_readme__and_if_you_still_don_t_understand_what_to_do__then_contact__support_in_our_discord_server_with_the_attached_screenshot_of_the_full_exception);
                 if (!args.Exit)


### PR DESCRIPTION
## Description
Set `error = true` in the `MainSafe` catch block so the installer actually reports failure.


**What is the current behavior?** (You can also link to an open issue here)
`error` is declared but never assigned, so `Environment.Exit(error ? 1 : 0)` always returns `0` - even on caught exceptions. Scripts checking the exit code think every install succeeded. 

**What is the new behavior?** (if this is a feature change)
Caught exceptions now produce exit code `1` when `--exit` is passed.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

**Other information**:
one-line fix.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
