### PR TITLE
refactor: obsolete HasFlagFast

### DIFF
--- a/EXILED/Exiled.API/Extensions/BitwiseExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/BitwiseExtensions.cs
@@ -69,12 +69,6 @@ namespace Exiled.API.Extensions
         /// <returns><see langword="true"/> if value is presented in flag. Otherwise, <see langword="false"/>.</returns>
         [Obsolete("Use Enum::HasFlag instead.")]
         public static bool HasFlagFast<T>(this T flag, T value)
-            where T : Enum
-        {
-            long flagValue = Convert.ToInt64(flag);
-            long valueValue = Convert.ToInt64(value);
-
-            return (flagValue & valueValue) == valueValue;
-        }
+            where T : Enum => flag.HasFlag(value);
     }
 }

--- a/EXILED/Exiled.API/Extensions/BitwiseExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/BitwiseExtensions.cs
@@ -67,6 +67,7 @@ namespace Exiled.API.Extensions
         /// <param name="value">Value to check in flag.</param>
         /// <typeparam name="T">The type of the enum.</typeparam>
         /// <returns><see langword="true"/> if value is presented in flag. Otherwise, <see langword="false"/>.</returns>
+        [Obsolete("Use Enum::HasFlag instead.")]
         public static bool HasFlagFast<T>(this T flag, T value)
             where T : Enum
         {


### PR DESCRIPTION
## Description
**Describe the changes** 
Marking `BitwiseExtensions.HasFlagFast` as an obsolete method to be removed in next major update due to its ineffectiveness in comparison with built-in Enum.HasFlag method

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?** (if this is a feature change)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:
the biggest pr in recent history lol?

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [ ] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
