### PR TITLE
fix: flashbang blinds teammates/self when friendly fire is off (master)

### DIFF
--- a/EXILED/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Map/ExplodingFlashGrenade.cs
@@ -73,7 +73,7 @@ namespace Exiled.Events.Patches.Events.Map
                     continue;
 
                 // LifeIdentifier check is needed to fix NW Bug https://git.scpslgame.com/northwood-qa/scpsl-bug-reporting/-/issues/2811
-                if (!IndividualFriendlyFire.CheckFriendlyFirePlayer(instance.PreviousOwner, player.ReferenceHub) && instance.PreviousOwner.LifeIdentifier == player.Footprint.LifeIdentifier)
+                if (!IndividualFriendlyFire.CheckFriendlyFirePlayer(instance.PreviousOwner, player.ReferenceHub) && instance.PreviousOwner.LifeIdentifier != player.Footprint.LifeIdentifier)
                     continue;
 
                 if (Physics.Linecast(instance.transform.position, player.CameraTransform.position, instance.BlindingMask))


### PR DESCRIPTION
## Description
**Describe the changes**
Fixes an inverted condition in `ExplodingFlashGrenade.ProcessEvent` that let
flashbangs blind teammates even when friendly fire is disabled.

Same fix as #838, targeted at `master` as requested (by Yamato) so it lands in the current
release line too.

**What is the current behavior?**
The teammate skip checks `instance.PreviousOwner.LifeIdentifier == player.Footprint.LifeIdentifier`.
`UniqueLifeIdentifier` is a global per-life counter, so that only matches when
`player` is the thrower himself, never a teammate. The `continue` therefore
never runs for teammates and they get flashed with FF off.

This came from inlining the old `!instance.PreviousOwner.CompareLife(player.ReferenceHub)`
check. `CompareLife` is `LifeIdentifier == other...UniqueLifeIdentifier`, so the
rewrite dropped the negation and turned `!=` into `==`.

**What is the new behavior?**
Flipped back to `!=`, so the condition is true for every teammate again and they
are correctly skipped. The LifeIdentifier comparison stays in place, so the
NW #2811 fix intent is preserved.

**Does this PR introduce a breaking change?**
No.

**Other information**:
One-character logic fix, only affects flashbang targeting while `Server.FriendlyFire` is off.

<br />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations

<br />

## Submission checklist
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
