### PR TITLE
fix: add missing base-game SCP-914 processors

### DIFF
--- a/EXILED/Exiled.Events/Handlers/Internal/Round.cs
+++ b/EXILED/Exiled.Events/Handlers/Internal/Round.cs
@@ -23,7 +23,9 @@ namespace Exiled.Events.Handlers.Internal
     using Exiled.Events.EventArgs.Scp049;
     using Exiled.Loader;
     using Exiled.Loader.Features;
+    using global::Scp914.Processors;
     using InventorySystem;
+    using InventorySystem.Items;
     using InventorySystem.Items.Firearms.Attachments;
     using InventorySystem.Items.Firearms.Attachments.Components;
     using InventorySystem.Items.Usables;
@@ -48,6 +50,7 @@ namespace Exiled.Events.Handlers.Internal
         public static void OnWaitingForPlayers()
         {
             GenerateAttachments();
+            AddMissingScp914Processors();
             MultiAdminFeatures.CallEvent(MultiAdminFeatures.EventType.WAITING_FOR_PLAYERS);
 
             if (Events.Instance.Config.ShouldReloadConfigsAtRoundRestart)
@@ -169,6 +172,31 @@ namespace Exiled.Events.Handlers.Internal
 
                 ListPool<AttachmentIdentifier>.Pool.Return(attachmentIdentifiers);
                 HashSetPool<AttachmentSlot>.Pool.Return(attachmentsSlots);
+            }
+        }
+
+        private static void AddMissingScp914Processors()
+        {
+            foreach (KeyValuePair<ItemType, ItemBase> entry in InventoryItemLoader.AvailableItems)
+            {
+                ItemType itemType = entry.Key;
+                ItemBase item = entry.Value;
+
+                if (item is null || item.TryGetComponent<Scp914ItemProcessor>(out _))
+                {
+                    continue;
+                }
+
+                ItemType[] outputs = new[] { itemType };
+
+                StandardItemProcessor processor = item.gameObject.AddComponent<StandardItemProcessor>();
+
+                processor._roughOutputs = outputs;
+                processor._coarseOutputs = outputs;
+                processor._oneToOneOutputs = outputs;
+                processor._fineOutputs = outputs;
+                processor._veryFineOutputs = outputs;
+                processor._fireUpgradeTrigger = false;
             }
         }
     }


### PR DESCRIPTION
## Description
**Describe the changes** 
Fixes #718

**What is the current behavior?** (You can also link to an open issue here)
Some base-game items missing SCP-914 Processors.

**What is the new behavior?** (if this is a feature change)
Add passthrough processor to missing processor items.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If a plugin has added its own processor, issues might arise.

**Other information**:
Thanks to @RimuruChan for identifying the cause and providing a solution.
This is my first pull request for EXILED, so please let me know if there are any issues.
<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
