### PR TITLE
fix: Draw misusing a pooled NetworkWriter

### DIFF
--- a/EXILED/Exiled.API/Features/Draw.cs
+++ b/EXILED/Exiled.API/Features/Draw.cs
@@ -360,17 +360,15 @@ namespace Exiled.API.Features
             if (points == null || points.Length - offset < 2 || count - offset < 2)
                 return;
 
-            ArraySegment<byte> data;
-            using (NetworkWriterPooled writer = NetworkWriterPool.Get())
-            {
-                writer.WriteUShort((ushort)typeof(DrawableLineMessage).FullName.GetStableHashCode());
-                writer.WriteFloatNullable(duration);
-                writer.WriteColorNullable(color);
-                writer.WriteInt(count);
-                for (int i = offset; i < count + offset; i++)
-                    writer.Write(points[i]);
-                data = writer.ToArraySegment();
-            }
+            using NetworkWriterPooled writer = NetworkWriterPool.Get();
+
+            writer.WriteUShort((ushort)typeof(DrawableLineMessage).FullName.GetStableHashCode());
+            writer.WriteFloatNullable(duration);
+            writer.WriteColorNullable(color);
+            writer.WriteInt(count);
+            for (int i = offset; i < count + offset; i++)
+                writer.Write(points[i]);
+            ArraySegment<byte> data = writer.ToArraySegment();
 
             if (players != null)
             {


### PR DESCRIPTION
## Description
**Describe the changes** 
So tldr; Draw.Send returns a pooled NetworkWriter to the pool too early (before it's data is **sent**, not converted to ArraySegment<byte>)

So if something later in the method calls for a pooled writer, it can get the same writer, writer data to it, then the ArraySegment<byte>'s data gets changed (because it's basically a wrapper) before the data is sent (where it's probably copied properly). I just changed the method to keep the pooled writer until the method returns

**What is the current behavior?** (You can also link to an open issue here)
Calling Draw methods using Player.List / Player.Enumerable instead of null can kick clients

**What is the new behavior?** (if this is a feature change)
No kick

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
